### PR TITLE
docs: add pre-affiliate monetization guide

### DIFF
--- a/docs/10/article.html
+++ b/docs/10/article.html
@@ -1,0 +1,79 @@
+<div class="lg:w-[calc(100%-380px)] lg:border-l lg:border-l-border lg:pl-0 2xl:w-[calc(100%-380px-350px)] 2xl:pr-0 2xl:border-r 2xl:border-r-border">
+  <div class="max-w-full px-0 pt-7 lg:pt-10 lg:pl-[46px] 2xl:pr-[46px]">
+    <article class="content prose max-w-full px-0 py-0">
+      <h2 id="earning-before-affiliate-what-you-can-do">Earning Before Affiliate – What You Can Do</h2>
+
+      <h2 id="yes-you-can-earn-before-affiliate">Yes — You Can Earn Before Affiliate</h2>
+      <p>On NOIZ, creators are eligible for monetization as soon as they verify their identity and complete required legal documents. You don’t need to be a badge-holding Affiliate or Partner to start earning ⚡︎dB.</p>
+      <ul>
+        <li>⚡︎dB (Charged Decibels) can be earned through platform activity immediately after onboarding</li>
+        <li>You do not need to hit a viewer count, follower number, or stream hour minimum to unlock monetization</li>
+        <li>The Affiliate badge does not gate access to cashout — legal verification is the only requirement</li>
+        <li>NOIZ separates badges from monetization to support creators from day one, without artificial milestones</li>
+      </ul>
+
+      <h2 id="how-you-can-accumulate-db-early">How You Can Accumulate ⚡︎dB Early</h2>
+      <p>Once your legal forms are complete, you're fully eligible to earn and withdraw ⚡︎dB.</p>
+      <p>You earn ⚡︎dB when:</p>
+      <ul>
+        <li>Viewers support you with Decibels (subs, boosts, tips, etc.)</li>
+        <li>Subs are gifted to your channel (each 500 dB sub becomes ⚡︎dB)</li>
+        <li>Viewers complete Quests on your channel</li>
+        <li>Users support your Marketplace listings (if you’re an Artist or Developer)</li>
+      </ul>
+      <p>⚡︎dB accumulates through direct community support — it is never earned by purchasing Decibels yourself.</p>
+
+      <h2 id="what-the-affiliate-badge-actually-unlocks">What the Affiliate Badge Actually Unlocks</h2>
+      <p>The Affiliate badge is a recognition level — not a gate to monetization.</p>
+      <p>What it changes:</p>
+      <ul>
+        <li>Revenue split increases (from Verified to Affiliate, you go from 50% to 60%)</li>
+        <li>Sub badge visibility in other chats (Affiliate becomes your default chat badge outside your own channel)</li>
+        <li>Unlocks additional emote slots, support badge tiers, and access to certain analytics</li>
+      </ul>
+      <p>It does not unlock monetization or cashout — those begin once you're verified and complete your paperwork.</p>
+
+      <h2 id="why-monetization-starts-early">Why Monetization Starts Early</h2>
+      <p>Unlike Twitch or YouTube, NOIZ doesn't wait until you're "big enough" to be rewarded.</p>
+      <ul>
+        <li>⚡︎dB earned before Affiliate can be cashed out at any time — no need to reapply or reach a tier</li>
+        <li>Every viewer action that supports you helps your long-term growth</li>
+        <li>Affiliate, Partner, and Partner+ simply enhance your tools and recognition — they don’t unlock earning</li>
+        <li>NOIZ believes creators should be rewarded for activity and community support — not artificial thresholds</li>
+      </ul>
+
+      <h2 id="what-you-can-do-with-db-pre-affiliate">What You Can Do With ⚡︎dB Pre-Affiliate</h2>
+      <p>With even a single ⚡︎dB in your account, you already have access to:</p>
+      <ul>
+        <li>Cashout tools (once you hit the 10,000 ⚡︎dB minimum)</li>
+        <li>Monetization dashboard (support history, top contributors)</li>
+        <li>Progress tracking for badge milestones</li>
+        <li>Participation in sponsored Quests (if available)</li>
+      </ul>
+      <p>Your journey as a monetized creator starts the moment your legal access is cleared — badges are just recognition, not requirements.</p>
+
+      <h2 id="tips-to-grow-faster-optional">Tips to Grow Faster (Optional)</h2>
+      <p>If you're working toward Affiliate or beyond, these can help:</p>
+      <ul>
+        <li>Stream consistently — the algorithm values activity over size</li>
+        <li>Use correct stream tags and maturity labels for visibility</li>
+        <li>Enable and refresh Quests often to drive engagement</li>
+        <li>Participate in platform-wide events and Quest chains</li>
+        <li>Let viewers know they can support with dB — but never pressure or guilt</li>
+      </ul>
+      <p>Badges will come naturally as you engage and grow.</p>
+
+      <h2 id="faq">FAQ</h2>
+      <dl>
+        <dt>Can I earn ⚡︎dB without the Affiliate badge?</dt>
+        <dd>Yes. Once verified, you are fully monetized and can cash out ⚡︎dB as long as you've reached 10,000.</dd>
+        <dt>What is the purpose of the Affiliate badge then?</dt>
+        <dd>It’s a recognition tier — it improves your rev split, unlocks cosmetic perks, and signals trust to viewers.</dd>
+        <dt>Do I need to apply for Affiliate?</dt>
+        <dd>No. NOIZ automatically awards badge tiers once you meet progression thresholds.</dd>
+        <dt>If I hit 10,000 ⚡︎dB before Affiliate, can I cash out?</dt>
+        <dd>Yes, absolutely — as long as your legal documents are complete and your account is verified.</dd>
+      </dl>
+    </article>
+  </div>
+</div>

--- a/docs/10/sidebar.html
+++ b/docs/10/sidebar.html
@@ -1,0 +1,114 @@
+<aside class="sidebar overflow-auto lg:!sticky lg:!top-[95px] lg:max-h-[calc(100vh-100px)] lg:!w-full lg:!py-10 lg:!pr-[46px]">
+  <form class="border-border mb-10 hidden w-full justify-between rounded-xl border sm:rounded-2xl lg:flex">
+    <input type="search" class="font-secondary placeholder:text-text/50 w-full border-0 bg-transparent p-3 pl-6 pr-0 placeholder:text-sm focus:border-0 focus:ring-0" data-target="search-modal" placeholder="Search The Doc">
+    <button data-target="search-modal" type="button" class="pl-3 pr-6">
+      <i class="fa-solid fa-magnifying-glass text-theme-dark"></i>
+    </button>
+  </form>
+  <ul class="sidebar-list">
+    <li data-nav-id="" title="Getting Started" class="active group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Getting Started</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/start.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="active group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/requirments/" data-accordion="">Requirments</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/installation/" data-accordion="">Installation</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/configuration/" data-accordion="">Configuration</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/customization/" data-accordion="">Customization</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/elements/" data-accordion="">Elements</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Account Bill" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Account Bill</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/bill.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/windows/" data-accordion="">Windows</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Our Features" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Our Features</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/feature.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Theme Facility" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Theme Facility</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/facility.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+  </ul>
+</aside>
+
+

--- a/docs/10/table-of-contents.html
+++ b/docs/10/table-of-contents.html
@@ -1,0 +1,24 @@
+<div class="hidden w-[350px] lg:pl-[28px] 2xl:block">
+  <div class="cs-scrollbar sticky top-[105px] hidden max-h-[calc(100vh-100px)] overflow-auto pt-10 lg:block lg:overflow-auto lg:transition-none 2xl:block">
+    <div id="toc-wrapper">
+      <div class="toc-heading">
+        <h2 class="text-h5 font-medium">Table of Contents</h2>
+      </div>
+      <nav id="TableOfContents">
+        <ol>
+          <li>
+            <ol>
+              <li><a href="#yes-you-can-earn-before-affiliate">Yes — You Can Earn Before Affiliate</a></li>
+              <li><a href="#how-you-can-accumulate-db-early">How You Can Accumulate ⚡︎dB Early</a></li>
+              <li><a href="#what-the-affiliate-badge-actually-unlocks">What the Affiliate Badge Actually Unlocks</a></li>
+              <li><a href="#why-monetization-starts-early">Why Monetization Starts Early</a></li>
+              <li><a href="#what-you-can-do-with-db-pre-affiliate">What You Can Do With ⚡︎dB Pre-Affiliate</a></li>
+              <li><a href="#tips-to-grow-faster-optional">Tips to Grow Faster (Optional)</a></li>
+              <li><a href="#faq">FAQ</a></li>
+            </ol>
+          </li>
+        </ol>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/docs/documents.json
+++ b/docs/documents.json
@@ -90,5 +90,15 @@
       "progression",
       "faq"
     ]
+  },
+  {
+    "documentId": 10,
+    "title": "Earning Before Affiliate – What You Can Do",
+    "desccription": "How to earn ⚡︎dB before reaching Affiliate status.",
+    "tags": [
+      "monetization",
+      "affiliate",
+      "db"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- document how creators can earn ⚡︎dB before reaching Affiliate status
- register new "Earning Before Affiliate – What You Can Do" guide in documents list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f870f942c8324adf38af88c2d4025