### PR TITLE
Add Chat Roles & Badge Color Guide

### DIFF
--- a/docs/11/article.html
+++ b/docs/11/article.html
@@ -1,0 +1,74 @@
+<div class="lg:w-[calc(100%-380px)] lg:border-l lg:border-l-border lg:pl-0 2xl:w-[calc(100%-380px-350px)] 2xl:pr-0 2xl:border-r 2xl:border-r-border">
+  <div class="max-w-full px-0 pt-7 lg:pt-10 lg:pl-[46px] 2xl:pr-[46px]">
+    <article class="content prose max-w-full px-0 py-0">
+      <h2 id="what-are-chat-roles">What Are Chat Roles on NOIZ?</h2>
+      <p>On NOIZ, chat roles are visual indicators that help identify a user’s status, trust level, or platform function. These badges appear in chat messages, user profiles, channel dashboards, and leaderboards. Roles serve cosmetic and functional purposes, highlighting contributors, moderators, builders, or official representatives.</p>
+      <p>There are two main types of roles:</p>
+      <ul>
+        <li><strong>Automatic roles</strong> – earned through platform activity (e.g. Affiliate, Sub Gifter, Quest Participant)</li>
+        <li><strong>Assigned roles</strong> – granted manually by NOIZ staff or system triggers (e.g. DCT, Staff, Pathweaver, Ambassador)</li>
+      </ul>
+      <p>Users can have multiple roles, but only one badge is shown in chat at a time; the highest‑trust or platform‑critical badge takes priority.</p>
+
+      <h2 id="platform-wide-roles-and-their-badges">Platform-Wide Roles and Their Badges</h2>
+      <p>These roles appear across all of NOIZ, not just within individual channels.</p>
+      <table>
+        <thead>
+          <tr><th>Role</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>NOIZ Staff</td><td>Employees including admins, legal/compliance, and support leads; use a unique badge color.</td></tr>
+          <tr><td>Staff Developer</td><td>Internal NOIZ developers building platform infrastructure; similar badge to “Developer” but with a staff color.</td></tr>
+          <tr><td>DCT</td><td>Dissonance Compliance Team with global moderation powers.</td></tr>
+          <tr><td>Staff Admin</td><td>Senior staff handling legal moderation, KYC escalations, and sensitive reports; usually hidden unless acting officially.</td></tr>
+          <tr><td>Ambassador</td><td>Users who reach referral milestones and help grow the platform; badge is public in chat.</td></tr>
+          <tr><td>Sponsor</td><td>Verified developers, publishers, or brands running official Quest campaigns in partnership with NOIZ.</td></tr>
+        </tbody>
+      </table>
+
+      <h2 id="automatic-roles-displayed-in-chat">Automatic Roles Displayed in Chat</h2>
+      <p>These roles are granted automatically based on activity or support milestones.</p>
+      <table>
+        <thead>
+          <tr><th>Role</th><th>Trigger</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Affiliate</td><td>Creator has met monetization entry criteria and completed verification.</td></tr>
+          <tr><td>Partner</td><td>Creator meets higher trust and engagement thresholds; badge displayed by default.</td></tr>
+          <tr><td>Partner+</td><td>Legacy or standout creators with high-level privileges; badge shown in most views.</td></tr>
+          <tr><td>Sub Gifter</td><td>Viewer who gifts Decibel-based subs; badge color changes with total gifted (5 to 5000).</td></tr>
+          <tr><td>Vibe Badge Holder</td><td>Badge visible only in the creator’s chat; earned through accumulated Vibe.</td></tr>
+          <tr><td>Support Milestone</td><td>Time-based or gifting milestones like 1 year subscribed or 1000 dB gifted.</td></tr>
+        </tbody>
+      </table>
+      <p>Gifter and Vibe badges stack separately from monetization badges. In your own channel, your time-based badge is shown by default unless manually changed.</p>
+
+      <h2 id="role-display-priority-context">Role Display Priority &amp; Context</h2>
+      <ul>
+        <li>In their own chat, users display their time-based loyalty badge.</li>
+        <li>In another creator’s chat, the platform-level badge (Affiliate, Partner, Partner+) is shown.</li>
+        <li>Staff, Admin, or DCT badges override all others when acting in an official capacity.</li>
+      </ul>
+      <p>Badge switching or customization may become available depending on context and permissions.</p>
+
+      <h2 id="future-role-expansions">Future Role Expansions</h2>
+      <p>NOIZ plans to expand the role system with additional badges:</p>
+      <ul>
+        <li>Verified Artist – for creators with listed Marketplace assets</li>
+        <li>Verified Developer – for users who build approved plugins, overlays, and tools</li>
+        <li>Pathweaver – for users who operate trusted relays and support platform infrastructure</li>
+        <li>Quest Champion – for high quest engagement across campaigns</li>
+      </ul>
+      <p>These roles will follow the same color-coded badge structure and appear automatically once earned.</p>
+
+      <h2 id="faq">FAQ</h2>
+      <ul>
+        <li><strong>Can I choose which badge shows in chat?</strong><br>Platform badges show by default; in your own chat, the time-based badge is prioritized.</li>
+        <li><strong>What if I have multiple roles?</strong><br>The highest-priority badge is displayed automatically. Some creators may unlock badge-switching later.</li>
+        <li><strong>Can viewers see if someone is Staff or DCT?</strong><br>Yes, when the user acts in an official capacity, though staff may observe anonymously.</li>
+        <li><strong>Can I earn multiple badges at once?</strong><br>Yes, users can accumulate gifting, time-based, Vibe, Partner+, and other badges.</li>
+        <li><strong>Are there secret roles?</strong><br>Some moderation roles are hidden, but all chat-visible roles are standardized.</li>
+      </ul>
+    </article>
+  </div>
+</div>

--- a/docs/11/sidebar.html
+++ b/docs/11/sidebar.html
@@ -1,0 +1,114 @@
+<aside class="sidebar overflow-auto lg:!sticky lg:!top-[95px] lg:max-h-[calc(100vh-100px)] lg:!w-full lg:!py-10 lg:!pr-[46px]">
+  <form class="border-border mb-10 hidden w-full justify-between rounded-xl border sm:rounded-2xl lg:flex">
+    <input type="search" class="font-secondary placeholder:text-text/50 w-full border-0 bg-transparent p-3 pl-6 pr-0 placeholder:text-sm focus:border-0 focus:ring-0" data-target="search-modal" placeholder="Search The Doc">
+    <button data-target="search-modal" type="button" class="pl-3 pr-6">
+      <i class="fa-solid fa-magnifying-glass text-theme-dark"></i>
+    </button>
+  </form>
+  <ul class="sidebar-list">
+    <li data-nav-id="" title="Getting Started" class="active group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Getting Started</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/start.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="active group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/requirments/" data-accordion="">Requirments</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/installation/" data-accordion="">Installation</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/configuration/" data-accordion="">Configuration</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/customization/" data-accordion="">Customization</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/elements/" data-accordion="">Elements</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Account Bill" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Account Bill</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/bill.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/windows/" data-accordion="">Windows</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Our Features" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Our Features</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/feature.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Theme Facility" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Theme Facility</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/facility.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+  </ul>
+</aside>
+
+

--- a/docs/11/table-of-contents.html
+++ b/docs/11/table-of-contents.html
@@ -1,0 +1,23 @@
+<div class="hidden w-[350px] lg:pl-[28px] 2xl:block">
+  <div class="cs-scrollbar sticky top-[105px] hidden max-h-[calc(100vh-100px)] overflow-auto pt-10 lg:block lg:overflow-auto lg:transition-none 2xl:block">
+    <div id="toc-wrapper">
+      <div class="toc-heading">
+        <h2 class="text-h5 font-medium">Table of Contents</h2>
+      </div>
+      <nav id="TableOfContents">
+        <ol>
+          <li>
+            <ol>
+              <li><a href="#what-are-chat-roles">What Are Chat Roles on NOIZ?</a></li>
+              <li><a href="#platform-wide-roles-and-their-badges">Platform-Wide Roles and Their Badges</a></li>
+              <li><a href="#automatic-roles-displayed-in-chat">Automatic Roles Displayed in Chat</a></li>
+              <li><a href="#role-display-priority-context">Role Display Priority &amp; Context</a></li>
+              <li><a href="#future-role-expansions">Future Role Expansions</a></li>
+              <li><a href="#faq">FAQ</a></li>
+            </ol>
+          </li>
+        </ol>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/docs/documents.json
+++ b/docs/documents.json
@@ -100,5 +100,15 @@
       "affiliate",
       "db"
     ]
+  },
+  {
+    "documentId": 11,
+    "title": "Chat Roles & Badge Color Guide",
+    "desccription": "Guide to chat roles, badge colors, and display priority on NOIZ.",
+    "tags": [
+      "roles",
+      "badges",
+      "chat"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- Document chat roles, badge types, display priority, and upcoming roles.
- Register the guide in the documents index.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f8c7bb0e8832493ea7e7ac71410dd