### PR TITLE
Replace financial terminology with support token phrasing

### DIFF
--- a/docs/1/article.html
+++ b/docs/1/article.html
@@ -35,7 +35,7 @@
       <p><strong>Why we ask for identity verification:</strong></p>
       <ul>
         <li>Prevent fraud and abuse.</li>
-        <li>Unlock monetization (⚡︎dB cashouts, quests, marketplace, etc.).</li>
+        <li>Unlock monetization (⚡︎dB redemptions, quests, marketplace, etc.).</li>
       </ul>
       <p><strong>What we ask for:</strong></p>
       <ul>

--- a/docs/10/article.html
+++ b/docs/10/article.html
@@ -8,7 +8,7 @@
       <ul>
         <li>⚡︎dB (Charged Decibels) can be earned through platform activity immediately after onboarding</li>
         <li>You do not need to hit a viewer count, follower number, or stream hour minimum to unlock monetization</li>
-        <li>The Affiliate badge does not gate access to cashout — legal verification is the only requirement</li>
+        <li>The Affiliate badge does not gate access to redemption — legal verification is the only requirement</li>
         <li>NOIZ separates badges from monetization to support creators from day one, without artificial milestones</li>
       </ul>
 
@@ -21,7 +21,7 @@
         <li>Viewers complete Quests on your channel</li>
         <li>Users support your Marketplace listings (if you’re an Artist or Developer)</li>
       </ul>
-      <p>⚡︎dB accumulates through direct community support — it is never earned by purchasing Decibels yourself.</p>
+      <p>⚡︎dB accumulates through direct community support — it is never earned by unlocking Decibels yourself.</p>
 
       <h2 id="what-the-affiliate-badge-actually-unlocks">What the Affiliate Badge Actually Unlocks</h2>
       <p>The Affiliate badge is a recognition level — not a gate to monetization.</p>
@@ -31,12 +31,12 @@
         <li>Sub badge visibility in other chats (Affiliate becomes your default chat badge outside your own channel)</li>
         <li>Unlocks additional emote slots, support badge tiers, and access to certain analytics</li>
       </ul>
-      <p>It does not unlock monetization or cashout — those begin once you're verified and complete your paperwork.</p>
+      <p>It does not unlock monetization or redemption — those begin once you're verified and complete your paperwork.</p>
 
       <h2 id="why-monetization-starts-early">Why Monetization Starts Early</h2>
       <p>Unlike Twitch or YouTube, NOIZ doesn't wait until you're "big enough" to be rewarded.</p>
       <ul>
-        <li>⚡︎dB earned before Affiliate can be cashed out at any time — no need to reapply or reach a tier</li>
+        <li>⚡︎dB earned before Affiliate can be redeemed at any time — no need to reapply or reach a tier</li>
         <li>Every viewer action that supports you helps your long-term growth</li>
         <li>Affiliate, Partner, and Partner+ simply enhance your tools and recognition — they don’t unlock earning</li>
         <li>NOIZ believes creators should be rewarded for activity and community support — not artificial thresholds</li>
@@ -45,12 +45,12 @@
       <h2 id="what-you-can-do-with-db-pre-affiliate">What You Can Do With ⚡︎dB Pre-Affiliate</h2>
       <p>With even a single ⚡︎dB in your account, you already have access to:</p>
       <ul>
-        <li>Cashout tools (once you hit the 10,000 ⚡︎dB minimum)</li>
+        <li>Redemption tools (once you hit the 10,000 ⚡︎dB minimum)</li>
         <li>Monetization dashboard (support history, top contributors)</li>
         <li>Progress tracking for badge milestones</li>
         <li>Participation in sponsored Quests (if available)</li>
       </ul>
-      <p>Your journey as a monetized creator starts the moment your legal access is cleared — badges are just recognition, not requirements.</p>
+      <p>Your journey as a supported creator starts the moment your legal access is cleared — badges are just recognition, not requirements.</p>
 
       <h2 id="tips-to-grow-faster-optional">Tips to Grow Faster (Optional)</h2>
       <p>If you're working toward Affiliate or beyond, these can help:</p>
@@ -66,12 +66,12 @@
       <h2 id="faq">FAQ</h2>
       <dl>
         <dt>Can I earn ⚡︎dB without the Affiliate badge?</dt>
-        <dd>Yes. Once verified, you are fully monetized and can cash out ⚡︎dB as long as you've reached 10,000.</dd>
+        <dd>Yes. Once verified, you are fully eligible for earnings and can redeem ⚡︎dB as long as you've reached 10,000.</dd>
         <dt>What is the purpose of the Affiliate badge then?</dt>
         <dd>It’s a recognition tier — it improves your rev split, unlocks cosmetic perks, and signals trust to viewers.</dd>
         <dt>Do I need to apply for Affiliate?</dt>
         <dd>No. NOIZ automatically awards badge tiers once you meet progression thresholds.</dd>
-        <dt>If I hit 10,000 ⚡︎dB before Affiliate, can I cash out?</dt>
+        <dt>If I hit 10,000 ⚡︎dB before Affiliate, can I redeem?</dt>
         <dd>Yes, absolutely — as long as your legal documents are complete and your account is verified.</dd>
       </dl>
     </article>

--- a/docs/13/article.html
+++ b/docs/13/article.html
@@ -2,7 +2,7 @@
   <div class="max-w-full px-0 pt-7 lg:pt-10 lg:pl-[46px] 2xl:pr-[46px]">
     <article class="content prose max-w-full px-0 py-0">
       <h2 id="overview">Overview</h2>
-      <p>The NOIZ Marketplace is a platform for creators, artists, and developers to share digital assets in exchange for support through Decibels (dB). All digital assets on NOIZ are unlocked through support contributions and are granted as non-exclusive, non-transferable licenses for in-platform use. These assets are not "purchased" in the traditional sense and no ownership is transferred.</p>
+      <p>The NOIZ Marketplace is a platform for creators, artists, and developers to share digital assets in exchange for support through Decibels (dB). All digital assets on NOIZ are unlocked through support contributions and are granted as non-exclusive, non-transferable licenses for in-platform use. These assets are not "sold" in the traditional sense and no ownership is transferred.</p>
 
       <h2 id="key-terminology">Key Terminology</h2>
       <ul>
@@ -72,7 +72,7 @@
       <ul>
         <li>Can I download and use unlocked assets on another platform?<br>No. Assets are licensed for use on NOIZ only unless explicitly marked otherwise by the creator.</li>
         <li>What happens if the artist deletes the listing?<br>You will retain access to the unlocked version unless the asset is removed due to a platform or legal policy violation.</li>
-        <li>Is unlocking considered a payment or purchase?<br>No. It is a support-based action that grants licensed use of a digital good.</li>
+        <li>Is unlocking considered a transaction or sale?<br>No. It is a support-based action that grants licensed use of a digital good.</li>
         <li>Can I refund Decibels used to unlock an item?<br>No. All Decibel contributions are considered support and are non-refundable unless part of a verified policy violation.</li>
       </ul>
     </article>

--- a/docs/14/article.html
+++ b/docs/14/article.html
@@ -2,7 +2,7 @@
   <div class="max-w-full px-0 pt-7 lg:pt-10 lg:pl-[46px] 2xl:pr-[46px]">
     <article class="content prose max-w-full px-0 py-0">
       <h2 id="refund-philosophy-on-noiz">Refund Philosophy on NOIZ</h2>
-      <p>NOIZ operates using Decibels, a platform-specific virtual support system. All actions involving Decibels — including subscriptions, tips, boosts, and marketplace unlocks — are framed as digital support or platform interaction, not purchases.</p>
+      <p>NOIZ operates using Decibels, a platform-specific virtual support system. All actions involving Decibels — including subscriptions, tips, boosts, and marketplace unlocks — are framed as digital support or platform interaction, not sales.</p>
       <p>Because of this framing:</p>
       <ul>
         <li>Support actions are non-refundable, as they do not constitute the exchange of goods or services in the traditional sense.</li>
@@ -10,7 +10,7 @@
       </ul>
       <p>Refunds may be granted in specific cases such as:</p>
       <ul>
-        <li>Unauthorized Decibel purchases (e.g., account compromise)</li>
+        <li>Unauthorized Decibel unlocks (e.g., account compromise)</li>
         <li>Duplicate charges or confirmed technical failures</li>
         <li>Rule-breaking behavior in Marketplace or Sponsored Quest systems</li>
       </ul>
@@ -22,14 +22,14 @@
         <li>Tipping or boosting a creator – These are voluntary, non-transactional actions</li>
         <li>Gifted subs – Once gifted, support is delivered and cannot be retracted</li>
         <li>Quest contributions – Unless tied to a verified system failure or a revoked Sponsored Quest</li>
-        <li>Completed dB purchases – If Decibels were successfully delivered to your account, the transaction is considered fulfilled</li>
+        <li>Completed dB unlocks – If Decibels were successfully delivered to your account, the transaction is considered fulfilled</li>
         <li><strong>Reminder:</strong> support is not ownership. There is no guarantee of content delivery, access, or performance when using Decibels.</li>
       </ul>
 
       <h2 id="eligible-refund-situations">Eligible Refund Situations</h2>
       <p>You may be eligible for a refund in limited and specific cases, such as:</p>
       <ul>
-        <li>Unauthorized dB purchases made via a compromised Constellation account</li>
+        <li>Unauthorized dB unlocks made via a compromised Constellation account</li>
         <li>System failures that result in:
           <ul>
             <li>Duplicate charges</li>
@@ -54,7 +54,7 @@
       <h2 id="how-to-request-a-refund">How to Request a Refund</h2>
       <p>To initiate a refund review, follow these steps:</p>
       <ol>
-        <li>Visit the NOIZ Support Portal or your Constellation Purchase History</li>
+        <li>Visit the NOIZ Support Portal or your Constellation Transaction History</li>
         <li>Locate the transaction in question</li>
         <li>Click “Report an Issue”</li>
         <li>Submit a ticket including:
@@ -78,28 +78,28 @@
       </ol>
 
       <h2 id="chargebacks-and-fraud-protection">Chargebacks and Fraud Protection</h2>
-      <p>Chargebacks filed directly with your payment provider (e.g., credit card) bypass NOIZ’s dispute system and can have serious consequences:</p>
+      <p>Chargebacks filed directly with your financial provider (e.g., credit card) bypass NOIZ’s dispute system and can have serious consequences:</p>
       <ul>
         <li>Automatic account restriction or ban</li>
         <li>Loss of access to pending ⚡︎dB or Marketplace tools</li>
         <li>Required KYC re-verification for future monetization eligibility</li>
       </ul>
-      <p>If you're unsure or concerned about a transaction, always open a ticket first — our team can help resolve issues faster and more safely than your payment provider.</p>
+      <p>If you're unsure or concerned about a transaction, always open a ticket first — our team can help resolve issues faster and more safely than your financial provider.</p>
 
       <h2 id="refund-method-and-timing">Refund Method &amp; Timing</h2>
       <ul>
         <li>Most refunds will be returned as dB to your NOIZ account</li>
-        <li>In rare or complex system issues, refunds may be re-routed through your original payment method</li>
+        <li>In rare or complex system issues, refunds may be re-routed through your original funding method</li>
         <li>In cases of technical failure, missing Decibels may be auto-restored without a formal refund process</li>
       </ul>
-      <p>Refund timelines can vary depending on the payment processor, but most are completed within 5–10 business days once approved.</p>
+      <p>Refund timelines can vary depending on the funding processor, but most are completed within 5–10 business days once approved.</p>
 
       <h2 id="faq">Frequently Asked Questions (FAQ)</h2>
       <ul>
         <li><strong>Can I refund a gifted sub I didn’t mean to send?</strong><br>No. All gifted subs are treated as final digital support and are non-refundable.</li>
         <li><strong>What if someone tipped me accidentally?</strong><br>Support actions like tipping are voluntary and irreversible. If someone sends dB or ⚡︎dB to your channel, it becomes eligible support.</li>
         <li><strong>Do refunds affect streamer ⚡︎dB earnings?</strong><br>In very rare cases, yes. If a refunded transaction included Decibel support and fraud is verified, ⚡︎dB may be removed from the recipient’s account.</li>
-        <li><strong>Can I refund my own Marketplace listing purchase?</strong><br>Only if the asset is found to violate Marketplace policy (e.g., stolen artwork). Buyer remorse or creative mismatch is not grounds for a refund.</li>
+        <li><strong>Can I refund my own Marketplace listing unlock?</strong><br>Only if the asset is found to violate Marketplace policy (e.g., stolen artwork). Buyer remorse or creative mismatch is not grounds for a refund.</li>
       </ul>
     </article>
   </div>

--- a/docs/15/article.html
+++ b/docs/15/article.html
@@ -3,7 +3,7 @@
     <article class="content prose max-w-full px-0 py-0">
       <h2 id="the-power-of-interactive-support">The Power of Interactive Support</h2>
       <p>NOIZ is built on active, meaningful participation. Instead of relying on passive metrics like view counts, the platform rewards direct interaction — and viewer support plays a key role in that system.</p>
-      <p>Actions like gifting subs, boosting live streams, and completing quests all contribute to a creator’s visibility and progression. These actions are powered by Decibels (dB), NOIZ’s virtual support tokens, which are never framed as money or purchases.</p>
+      <p>Actions like gifting subs, boosting live streams, and completing quests all contribute to a creator’s visibility and progression. These actions are powered by Decibels (dB), NOIZ’s virtual support tokens, which are never framed as financial instruments or sales.</p>
       <p>Interactive support benefits everyone:</p>
       <ul>
         <li>Viewers unlock cosmetic perks, badge milestones, and personal rewards</li>
@@ -12,7 +12,7 @@
       </ul>
 
       <h2 id="sub-gifting-how-it-works">Sub Gifting: How It Works</h2>
-      <p>Viewers can gift subscriptions to others on NOIZ using 500 dB per sub. This is a support action, not a purchase — it unlocks non-financial, digital perks for both the recipient and the creator.</p>
+      <p>Viewers can gift subscriptions to others on NOIZ using 500 dB per sub. This is a support action, not a sale — it unlocks non-financial, digital perks for both the recipient and the creator.</p>
       <p>Recipients of a gifted sub receive:</p>
       <ul>
         <li>A sub badge, which may be time-based or custom</li>
@@ -52,7 +52,7 @@
         <li>Temporary Echostage weight boosts, if many quests are completed quickly</li>
       </ul>
       <p>Some Quest bonuses are sponsored, meaning they’re backed by verified brands or funded by NOIZ campaigns.</p>
-      <p>All Quest bonuses remain virtual and platform-contained — no fiat currency or off-platform goods are involved.</p>
+      <p>All Quest bonuses remain virtual and platform-contained — no fiat transactions or off-platform goods are involved.</p>
 
       <h2 id="how-creators-benefit">How Creators Benefit</h2>
       <p>Creators gain ⚡︎dB and increased visibility from viewer actions such as:</p>
@@ -67,7 +67,7 @@
         <li>Unlocking Vibe milestone badges</li>
         <li>Influencing dashboard stats and engagement insights</li>
       </ul>
-      <p>Boosts, in particular, affect Echostage routing only when fueled by viewer engagement — not raw currency or automation.</p>
+      <p>Boosts, in particular, affect Echostage routing only when fueled by viewer engagement — not raw token accumulation or automation.</p>
       <p>There is no leaderboard or payout bonus for boosts — they are a visibility tool, not a monetization mechanic.</p>
 
       <h2 id="boost-gift-transparency">Boost &amp; Gift Transparency</h2>
@@ -80,11 +80,11 @@
       </ul>
       <p>Viewers cannot boost or gift anonymously unless they’ve activated privacy settings — helping keep community activity transparent and accountable.</p>
 
-      <h2 id="support-vs-purchase-reminder">Support vs. Purchase Reminder</h2>
+      <h2 id="support-vs-transaction-reminder">Support vs. Transaction Reminder</h2>
       <p>It’s important to understand that NOIZ does not sell access, perks, or content.</p>
       <ul>
         <li>Gifting, boosting, and completing quests are support actions, not transactions</li>
-        <li>Streamers receive ⚡︎dB as recognition, not as payment or product compensation</li>
+        <li>Streamers receive ⚡︎dB as recognition, not as a fee or product compensation</li>
         <li>All interactions are framed as voluntary digital contributions within a virtual ecosystem</li>
       </ul>
       <p>This ensures that NOIZ remains legally compliant, creator-first, and free from transactional expectations.</p>

--- a/docs/15/table-of-contents.html
+++ b/docs/15/table-of-contents.html
@@ -14,7 +14,7 @@
               <li><a href="#quest-bonuses">Quest Bonuses</a></li>
               <li><a href="#how-creators-benefit">How Creators Benefit</a></li>
               <li><a href="#boost-gift-transparency">Boost &amp; Gift Transparency</a></li>
-              <li><a href="#support-vs-purchase-reminder">Support vs. Purchase Reminder</a></li>
+              <li><a href="#support-vs-transaction-reminder">Support vs. Transaction Reminder</a></li>
               <li><a href="#faq">Frequently Asked Questions (FAQ)</a></li>
             </ol>
           </li>

--- a/docs/16/article.html
+++ b/docs/16/article.html
@@ -6,22 +6,22 @@
       <p>It also clarifies that:</p>
       <ul>
         <li><strong>Constellation</strong> acts as an <strong>access ledger</strong>, not a wallet, exchange, or banking service.</li>
-        <li><strong>dB and ⚡︎dB are digital support tokens</strong>—not money or currency.</li>
-        <li>Cashout rules apply <strong>only to ⚡︎dB</strong>, and only if earned through community activity.</li>
+        <li><strong>dB and ⚡︎dB are digital support tokens</strong>—never legal tender or financial instruments.</li>
+          <li>Redemption rules apply <strong>only to ⚡︎dB</strong>, and only if earned through community activity.</li>
       </ul>
       <p>This policy is designed to protect NOIZ’s legal compliance, discourage abuse, and ensure that our reward systems are fair, non-speculative, and platform-contained.</p>
 
       <h2 id="what-is-constellation">What Is Constellation?</h2>
       <p><strong>Constellation</strong> is the access and identity system used across the NOIZ ecosystem. In addition to authentication, it acts as your <strong>virtual token container</strong>, tracking and displaying:</p>
       <ul>
-        <li>Your <strong>dB</strong> balance (Decibels you’ve purchased to support creators)</li>
+        <li>Your <strong>dB</strong> balance (Decibels you’ve unlocked to support creators)</li>
         <li>Your <strong>⚡︎dB</strong> balance (Charged Decibels you’ve earned from others)</li>
         <li>Your <strong>transaction history</strong> (sent, received, or earned)</li>
         <li>Your <strong>connected apps and services</strong></li>
       </ul>
       <p>Importantly, <strong>Constellation is <em>not</em> a financial wallet</strong>. It cannot:</p>
       <ul>
-        <li>Hold fiat currency</li>
+        <li>Hold fiat funds</li>
         <li>Facilitate withdrawals beyond what NOIZ explicitly allows</li>
         <li>Interact with external marketplaces or cryptocurrencies</li>
       </ul>
@@ -34,13 +34,13 @@
             <th>Type</th>
             <th>Description</th>
             <th>Exchangeable?</th>
-            <th>Cashout Eligible?</th>
+            <th>Redemption Eligible?</th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <td>dB</td>
-            <td>Purchased through Constellation</td>
+            <td>Unlocked through Constellation</td>
             <td>✅ Yes</td>
             <td>❌ No</td>
           </tr>
@@ -52,8 +52,8 @@
           </tr>
         </tbody>
       </table>
-      <p><strong>dB</strong> are <em>faded</em> Decibels—they’re acquired through the purchase of support tokens in Constellation and can only be used to interact within the platform. Once dB are used to support another user (e.g., through tipping, gifting subs, or marketplace actions), they <strong>become ⚡︎dB</strong> for that user.</p>
-      <p>This system ensures that only <strong>earned support</strong>, not purchased tokens, become eligible for redemption.</p>
+      <p><strong>dB</strong> are <em>faded</em> Decibels—they’re acquired by unlocking support tokens in Constellation and can only be used to interact within the platform. Once dB are used to support another user (e.g., through tipping, gifting subs, or marketplace actions), they <strong>become ⚡︎dB</strong> for that user.</p>
+      <p>This system ensures that only <strong>earned support</strong>, not unlocked tokens, become eligible for redemption.</p>
 
       <h2 id="db-usage-rules">dB Usage Rules</h2>
       <p>Your <strong>dB balance</strong> can be used for digital support actions such as:</p>
@@ -66,8 +66,8 @@
       <p>However:</p>
       <ul>
         <li>Once used, <strong>dB cannot be refunded</strong> (unless a verified system error occurs)</li>
-        <li><strong>dB cannot be “cashed out”</strong> under any circumstance</li>
-        <li><strong>dB are not currency</strong>, and cannot be used to purchase physical or off-platform goods</li>
+        <li><strong>dB cannot be redeemed</strong> under any circumstance</li>
+        <li><strong>dB are not legal tender</strong>, and cannot be used to obtain physical or off-platform goods</li>
       </ul>
       <p>Think of dB as <strong>support tokens</strong>—they unlock digital participation and engagement, but hold no financial entitlement or exchange value.</p>
 
@@ -80,20 +80,20 @@
         <li>Quest completions</li>
         <li>Marketplace redemptions</li>
       </ul>
-      <p>To <strong>cash out ⚡︎dB</strong>, you must meet all of the following:</p>
+      <p>To <strong>redeem ⚡︎dB</strong>, you must meet all of the following:</p>
       <ol>
         <li><strong>Reach Affiliate status</strong> or higher</li>
         <li><strong>Complete legal identity verification (KYC)</strong></li>
         <li><strong>Hold at least 10,000 ⚡︎dB</strong> in your account</li>
       </ol>
-      <p>You may also use ⚡︎dB <strong>in-platform</strong> for the same actions as dB (e.g., tipping other creators), or save it for cashout once eligible.</p>
+      <p>You may also use ⚡︎dB <strong>in-platform</strong> for the same actions as dB (e.g., tipping other creators), or save it for redemption once eligible.</p>
 
       <h2 id="internal-only-exchange-model">Internal-Only Exchange Model</h2>
       <p>NOIZ is a <strong>closed economy</strong>—Decibel transactions and balances are strictly limited to the NOIZ platform and Constellation ecosystem.</p>
       <p>NOIZ does <strong>not support</strong>:</p>
       <ul>
-        <li><strong>Cryptocurrency transactions or tokens</strong></li>
-        <li><strong>Fiat withdrawals</strong> outside of approved ⚡︎dB cashout</li>
+        <li><strong>Crypto-asset transactions or tokens</strong></li>
+        <li><strong>Fiat withdrawals</strong> outside of approved ⚡︎dB redemption</li>
         <li><strong>Third-party trading</strong>, resale, or swaps</li>
         <li><strong>NFTs or token speculation</strong></li>
       </ul>
@@ -105,13 +105,13 @@
       <ul>
         <li><strong>Tipping yourself</strong> using alternate accounts</li>
         <li><strong>Looping dB through shell accounts</strong></li>
-        <li><strong>Attempting to bypass KYC verification</strong> for cashout</li>
+        <li><strong>Attempting to bypass KYC verification</strong> for redemption</li>
       </ul>
       <p>If abuse is detected, NOIZ may:</p>
       <ul>
         <li><strong>Flag your account</strong> for review</li>
         <li><strong>Remove ⚡︎dB</strong> that was gained improperly</li>
-        <li><strong>Restrict monetization access</strong> or freeze cashout privileges</li>
+        <li><strong>Restrict monetization access</strong> or freeze redemption privileges</li>
       </ul>
       <p>Our priority is to keep the system safe for creators who participate fairly.</p>
 

--- a/docs/2/article.html
+++ b/docs/2/article.html
@@ -5,7 +5,7 @@
       <ul>
         <li>Anyone with a verified NOIZ account can start broadcasting — no exclusivity, contracts, or application necessary</li>
         <li>There is no invite system</li>
-        <li>You do not need to be monetized to go live</li>
+        <li>You do not need to be earning-eligible to go live</li>
         <li>Verification and legal compliance are the only requirements</li>
       </ul>
 
@@ -34,7 +34,7 @@
       </table>
       <ul>
         <li>Verified = Platform recognition</li>
-        <li>Affiliate = First monetized level</li>
+        <li>Affiliate = First earning-eligible level</li>
         <li>Partner = High-consistency creators</li>
         <li>Partner+ = Top contributors or community-driven impact</li>
       </ul>

--- a/docs/3/article.html
+++ b/docs/3/article.html
@@ -20,8 +20,8 @@
 
       <h2 id="difference">What Makes NOIZ Different</h2>
       <ul>
-        <li><strong>Decibel-Based Support:</strong> Instead of traditional money-based subscriptions, NOIZ uses Decibels (dB and ⚡︎dB), virtual support tokens that empower creators without financial framing.</li>
-        <li><strong>Digital-Only Monetization:</strong> All monetization is built around in-platform rewards, not “purchases.” Everything earned is tied to participation — never behind a paywall.</li>
+        <li><strong>Decibel-Based Support:</strong> Instead of traditional fiat-based subscriptions, NOIZ uses Decibels (dB and ⚡︎dB), virtual support tokens that empower creators without financial framing.</li>
+        <li><strong>Digital-Only Monetization:</strong> All monetization is built around in-platform rewards, not “sales.” Everything earned is tied to participation — never behind a paywall.</li>
         <li><strong>Relay-Driven Infrastructure:</strong> Rather than depending on central servers, streams are delivered through a network of trusted, community-hosted relays (run by Pathweavers). This avoids single points of failure and allows greater scalability.</li>
         <li><strong>Quest-Based Engagement:</strong> Viewers interact through Quests — tasks like watching, chatting, boosting, or gifting — earning rewards while deepening their connection to the stream.</li>
         <li><strong>Transparent Moderation:</strong> NOIZ’s moderation structure includes the DCT (Dissonance Compliance Team), Staff Admins, and platform tools. Enforcement actions are logged and tracked to ensure consistency and fairness.</li>
@@ -68,7 +68,7 @@
         <li>❌ We are not a Twitch clone — NOIZ was inspired by streaming’s potential, not its limitations.</li>
         <li>❌ We are not ad-funded — NOIZ runs zero ads. Sponsors engage through Quests, not banners or pre-rolls.</li>
         <li>❌ We are not hype-driven — we’re building systems that last, not chasing the next trend or platform war.</li>
-        <li>❌ We are not pay-to-win — there are no monetized boosts, no inflated views, no botting loopholes. Every interaction is earned and tracked internally.</li>
+        <li>❌ We are not pay-to-win — there are no token-based boosts, no inflated views, no botting loopholes. Every interaction is earned and tracked internally.</li>
       </ul>
       <p>NOIZ is for creators who want to build, grow, and belong. If that’s you — welcome home.</p>
     </article>

--- a/docs/4/article.html
+++ b/docs/4/article.html
@@ -3,7 +3,7 @@
     <article class="content prose max-w-full px-0 py-0">
       <h2 id="platform-overview">What Is NOIZ as a Platform?</h2>
       <p>NOIZ is a creator-first live streaming ecosystem that reimagines how digital support and infrastructure work together.</p>
-      <p>Unlike traditional platforms that prioritize monetization through fiat currency or advertising, NOIZ centers its economy around Decibels — a virtual support token system. This framing allows NOIZ to foster community-driven growth, non-exploitative monetization, and meaningful interaction across the platform.</p>
+      <p>Unlike traditional platforms that prioritize monetization through fiat-based transactions or advertising, NOIZ centers its economy around Decibels — a virtual support token system. This framing allows NOIZ to foster community-driven growth, non-exploitative monetization, and meaningful interaction across the platform.</p>
       <p>Rather than relying on centralized server farms, NOIZ is powered by a decentralized relay infrastructure, hosted by users who contribute bandwidth and routing (Pathweavers). The entire system is designed to be lightweight, scalable, and fair — without relying on crypto, ads, or pay-to-win mechanics.</p>
 
       <h2 id="channels">Channels: Your Creator Hub</h2>
@@ -80,8 +80,8 @@
       </ul>
       <p>All of this is powered by Decibels, which come in two forms:</p>
       <ul>
-        <li>dB — purchased by viewers for use on the platform (not cash-out eligible)</li>
-        <li>⚡︎dB — earned by creators through support and eligible for withdrawal (if monetization requirements are met)</li>
+        <li>dB — unlocked by viewers for use on the platform (not eligible for redemption)</li>
+        <li>⚡︎dB — earned by creators through support and eligible for redemption (if monetization requirements are met)</li>
       </ul>
       <p>Every action — whether you're watching, boosting, hosting a relay, or broadcasting — feeds into this system, ensuring that everyone’s contribution is recognized.</p>
     </article>

--- a/docs/5/article.html
+++ b/docs/5/article.html
@@ -44,14 +44,14 @@
       <p>Once monetization is enabled (post-KYC and Affiliate status), this panel becomes active.</p>
       <p>Features include:</p>
       <ul>
-        <li>⚡︎dB Cashout controls (available once you hit 10,000 ⚡︎dB)</li>
+        <li>⚡︎dB Redemption controls (available once you hit 10,000 ⚡︎dB)</li>
         <li>Viewer support log (gifts, tips, quest completions)</li>
         <li>Sub gifting and Boost tracking per stream</li>
         <li>Marketplace earnings overview (for Artists and Developers)</li>
         <li>Split percentage display, based on your tier (50%–80%)</li>
         <li>Real-time monetization status and earnings progress</li>
       </ul>
-      <p>This is where creators manage their income potential — within NOIZ’s virtual currency framing.</p>
+      <p>This is where creators manage their support potential — within NOIZ’s virtual support token framing.</p>
 
       <h2 id="chat-and-engagement-settings">Chat &amp; Engagement Settings</h2>
       <p>Build, moderate, and customize your community using the following tools:</p>
@@ -82,7 +82,7 @@
         <li>View feedback or disputes, if any arise</li>
         <li>Set tier unlocks: Gate content based on sub status, ⚡︎dB threshold, or loyalty</li>
       </ul>
-      <p>NOIZ doesn’t allow cash purchases — these listings are unlocked via Decibel support.</p>
+      <p>NOIZ doesn’t allow fiat-based unlocks — these listings are accessed via Decibel support.</p>
 
       <h2 id="profile-and-customization">Profile &amp; Customization</h2>
       <p>Adjust your public-facing presence:</p>

--- a/docs/9/article.html
+++ b/docs/9/article.html
@@ -7,7 +7,7 @@
       <p>NOIZ recognizes creators through a structured tier system that reflects platform activity, support, and engagement — not vanity metrics.</p>
       <ul>
         <li><strong>Verified:</strong> Entry recognition for creators with consistent activity and completed onboarding</li>
-        <li><strong>Affiliate:</strong> First monetized badge tier (unlocks cashout and support tools)</li>
+        <li><strong>Affiliate:</strong> First earning-eligible badge tier (unlocks redemption and support tools)</li>
         <li><strong>Partner:</strong> Mid-tier for creators with strong community interaction and platform presence</li>
         <li><strong>Partner+:</strong> Top-tier for long-term builders, community leaders, or official platform collaborators</li>
       </ul>

--- a/docs/documents.json
+++ b/docs/documents.json
@@ -154,7 +154,7 @@
   {
     "documentId": 16,
     "title": "Decibels Exchange & Wallet Use Policy",
-    "desccription": "Explains how Decibels and Charged Decibels can be exchanged, used, and cashed out inside Constellation.",
+    "desccription": "Explains how Decibels and Charged Decibels can be exchanged, used, and redeemed inside Constellation.",
     "tags": [
       "policy",
       "db",


### PR DESCRIPTION
## Summary
- Replaced references to currency, purchases, and cash outs with virtual support token language across documentation
- Clarified Decibel policy and redemption rules to avoid financial terminology
- Updated refund and progression guides to use support-focused wording

## Testing
- `npm test` *(fails: no package.json)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689143b3e6788324a23ba0979fd9a31c