### PR TITLE
docs: add payout schedule and revenue split guide

### DIFF
--- a/docs/17/article.html
+++ b/docs/17/article.html
@@ -1,0 +1,127 @@
+<div class="lg:w-[calc(100%-380px)] lg:border-l lg:border-l-border lg:pl-0 2xl:w-[calc(100%-380px-350px)] 2xl:pr-0 2xl:border-r 2xl:border-r-border">
+  <div class="max-w-full px-0 pt-7 lg:pt-10 lg:pl-[46px] 2xl:pr-[46px]">
+    <article class="content prose max-w-full px-0 py-0">
+      <h2 id="how-payouts-work-on-noiz">How Payouts Work on NOIZ</h2>
+      <p>NOIZ operates on a <strong>virtual token support system</strong>, where creators earn rewards through <strong>Charged Decibels (⚡︎dB)</strong>.</p>
+      <p>Payouts occur <strong>only</strong> when:</p>
+      <ul>
+        <li>⚡︎dB thresholds are met</li>
+        <li>Monetization eligibility is confirmed</li>
+      </ul>
+      <p>⚡︎dB can <strong>only</strong> be earned through:</p>
+      <ul>
+        <li>Support from <strong>other users</strong> (not yourself)</li>
+        <li>Viewer actions like subscriptions, tips, quests, boosts, or marketplace interactions</li>
+      </ul>
+      <blockquote>
+        <p>⚠️ Faded Decibels (dB) — which are purchased tokens — <strong>cannot</strong> be redeemed for fiat.</p>
+      </blockquote>
+
+      <h2 id="who-is-eligible-for-payouts">Who Is Eligible for Payouts</h2>
+      <p>You must meet <strong>all</strong> of the following criteria to redeem ⚡︎dB:</p>
+      <ul>
+        <li>Be at <strong>Affiliate level or higher</strong></li>
+        <li>Hold a minimum of <strong>10,000 ⚡︎dB</strong></li>
+        <li>Have <strong>completed KYC</strong> and submitted accurate payout information</li>
+        <li>Pass a <strong>platform review</strong> to ensure no abuse, fraud, or self-supporting behavior</li>
+      </ul>
+
+      <h2 id="charged-db-to-fiat-conversion-value">⚡︎dB to Fiat Conversion Value</h2>
+      <p>For eligible creators:</p>
+      <ul>
+        <li><strong>1 ⚡︎dB = $0.01 USD</strong></li>
+      </ul>
+      <p>This is a <strong>fixed internal recognition rate</strong> for reward purposes — it does <strong>not</strong> represent a tradable value or token exchange rate.</p>
+      <p>dB cannot be converted into fiat. Only ⚡︎dB (earned through legitimate user support) qualify for cashout.</p>
+
+      <h2 id="revenue-splits-by-creator-tier">Revenue Splits by Creator Tier</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Tier</th>
+            <th>Estimated ⚡︎dB-to-Creator Split</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Affiliate</td>
+            <td>50%</td>
+          </tr>
+          <tr>
+            <td>Partner</td>
+            <td>65%</td>
+          </tr>
+          <tr>
+            <td>Partner+</td>
+            <td>75%+ (invite-only)</td>
+          </tr>
+        </tbody>
+      </table>
+      <p><strong>Example:</strong> A viewer gifts 500 dB<br>
+      &rarr; Streamer receives 250 ⚡︎dB (if Affiliate)<br>
+      &rarr; Remaining value supports platform infrastructure, relays, moderation, and quest pools</p>
+      <blockquote>
+        <p>Splits are calculated based on Decibel input value, not fiat.</p>
+      </blockquote>
+
+      <h2 id="payout-schedule">Payout Schedule</h2>
+      <ul>
+        <li><strong>Payout requests are reviewed weekly</strong></li>
+        <li>Once approved, funds are processed within <strong>5–10 business days</strong></li>
+        <li><strong>Minimum payout = 10,000 ⚡︎dB ($100 equivalent)</strong></li>
+        <li>You may choose to:
+          <ul>
+            <li><strong>Hold ⚡︎dB</strong> and use them within the platform (support, marketplace, etc.)</li>
+            <li><strong>Redeem</strong> them once the payout threshold is met</li>
+          </ul>
+        </li>
+      </ul>
+
+      <h2 id="where-to-request-a-payout">Where to Request a Payout</h2>
+      <ul>
+        <li>Go to: <strong>Creator Dashboard → ⚡︎dB → Cashout</strong></li>
+        <li>If you don’t see the cashout option, it may be because:
+          <ul>
+            <li>You have not reached <strong>Affiliate status</strong></li>
+            <li>You have not passed KYC or completed payout info</li>
+            <li>You hold only <strong>dB</strong> (faded), not <strong>⚡︎dB</strong> (charged)</li>
+          </ul>
+        </li>
+      </ul>
+      <p>Your <strong>Constellation panel</strong> will show:</p>
+      <ul>
+        <li>Total Decibels</li>
+        <li>⚡︎dB eligible for cashout</li>
+        <li>Pending ⚡︎dB still under review or threshold</li>
+      </ul>
+
+      <h2 id="important-notes">Important Notes</h2>
+      <ul>
+        <li>NOIZ does <strong>not auto-convert</strong> your ⚡︎dB — you choose when to request payout</li>
+        <li>⚡︎dB may also be reused inside NOIZ (e.g., support other creators, unlock items)</li>
+        <li>Attempting to:
+          <ul>
+            <li>Loop purchased dB into ⚡︎dB</li>
+            <li>Gift Decibels to yourself via second accounts</li>
+            <li>Artificially trigger quests or boosts</li>
+          </ul>
+          may result in <strong>payout restriction or monetization suspension</strong>
+        </li>
+      </ul>
+
+      <h2 id="faq">FAQ</h2>
+      <ul>
+        <li><strong>Why can’t I cash out my dB?</strong><br>A: dB are support-only tokens. Only ⚡︎dB — earned through community interaction — are eligible for payout.</li>
+        <li><strong>Why is my payout request pending or held?</strong><br>A: Payouts may be held for review if:
+          <ul>
+            <li>KYC is incomplete</li>
+            <li>Anti-fraud systems flag unusual patterns</li>
+            <li>The Decibels were not properly charged</li>
+          </ul>
+        </li>
+        <li><strong>Can I change my revenue split?</strong><br>A: Splits are automatically determined by your creator tier. Advancement to higher tiers increases your split rate.</li>
+        <li><strong>Will NOIZ report payouts to tax authorities?</strong><br>A: Yes. All payouts are recorded, and NOIZ complies with applicable financial regulations. You may receive a tax form depending on your region and payout total.</li>
+      </ul>
+    </article>
+  </div>
+</div>

--- a/docs/17/sidebar.html
+++ b/docs/17/sidebar.html
@@ -1,0 +1,114 @@
+<aside class="sidebar overflow-auto lg:!sticky lg:!top-[95px] lg:max-h-[calc(100vh-100px)] lg:!w-full lg:!py-10 lg:!pr-[46px]">
+  <form class="border-border mb-10 hidden w-full justify-between rounded-xl border sm:rounded-2xl lg:flex">
+    <input type="search" class="font-secondary placeholder:text-text/50 w-full border-0 bg-transparent p-3 pl-6 pr-0 placeholder:text-sm focus:border-0 focus:ring-0" data-target="search-modal" placeholder="Search The Doc">
+    <button data-target="search-modal" type="button" class="pl-3 pr-6">
+      <i class="fa-solid fa-magnifying-glass text-theme-dark"></i>
+    </button>
+  </form>
+  <ul class="sidebar-list">
+    <li data-nav-id="" title="Getting Started" class="active group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Getting Started</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/start.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="active group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/requirments/" data-accordion="">Requirments</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/installation/" data-accordion="">Installation</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/configuration/" data-accordion="">Configuration</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/customization/" data-accordion="">Customization</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/elements/" data-accordion="">Elements</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Account Bill" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Account Bill</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/bill.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/windows/" data-accordion="">Windows</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Our Features" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Our Features</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/feature.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Theme Facility" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Theme Facility</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/facility.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+  </ul>
+</aside>
+
+

--- a/docs/17/table-of-contents.html
+++ b/docs/17/table-of-contents.html
@@ -1,0 +1,25 @@
+<div class="hidden w-[350px] lg:pl-[28px] 2xl:block">
+  <div class="cs-scrollbar sticky top-[105px] hidden max-h-[calc(100vh-100px)] overflow-auto pt-10 lg:block lg:overflow-auto lg:transition-none 2xl:block">
+    <div id="toc-wrapper">
+      <div class="toc-heading">
+        <h2 class="text-h5 font-medium">Table of Contents</h2>
+      </div>
+      <nav id="TableOfContents">
+        <ol>
+          <li>
+            <ol>
+              <li><a href="#how-payouts-work-on-noiz">How Payouts Work on NOIZ</a></li>
+              <li><a href="#who-is-eligible-for-payouts">Who Is Eligible for Payouts</a></li>
+              <li><a href="#charged-db-to-fiat-conversion-value">⚡︎dB to Fiat Conversion Value</a></li>
+              <li><a href="#revenue-splits-by-creator-tier">Revenue Splits by Creator Tier</a></li>
+              <li><a href="#payout-schedule">Payout Schedule</a></li>
+              <li><a href="#where-to-request-a-payout">Where to Request a Payout</a></li>
+              <li><a href="#important-notes">Important Notes</a></li>
+              <li><a href="#faq">FAQ</a></li>
+            </ol>
+          </li>
+        </ol>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/docs/documents.json
+++ b/docs/documents.json
@@ -93,8 +93,8 @@
   },
   {
     "documentId": 10,
-    "title": "Earning Before Affiliate – What You Can Do",
-    "desccription": "How to earn ⚡︎dB before reaching Affiliate status.",
+    "title": "Earning Before Affiliate \u2013 What You Can Do",
+    "desccription": "How to earn \u26a1\ufe0edB before reaching Affiliate status.",
     "tags": [
       "monetization",
       "affiliate",
@@ -160,6 +160,16 @@
       "db",
       "ledger",
       "exchange"
+    ]
+  },
+  {
+    "documentId": 17,
+    "title": "Token Payout Schedules & Revenue Split Explained",
+    "desccription": "How payouts work, revenue splits, and eligibility requirements.",
+    "tags": [
+      "monetization",
+      "payouts",
+      "db"
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- add guide on token payouts, revenue splits, and eligibility
- register new payout document in docs manifest

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68914eaa900c8324bdc04d89dd88b995