### PR TITLE
Add ad-free model and sponsored quests documentation

### DIFF
--- a/docs/21/article.html
+++ b/docs/21/article.html
@@ -1,0 +1,93 @@
+<div class="lg:w-[calc(100%-380px)] lg:border-l lg:border-l-border lg:pl-0 2xl:w-[calc(100%-380px-350px)] 2xl:pr-0 2xl:border-r 2xl:border-r-border">
+  <div class="max-w-full px-0 pt-7 lg:pt-10 lg:pl-[46px] 2xl:pr-[46px]">
+    <article class="content prose max-w-full px-0 py-0">
+      <h2 id="core-philosophy">NOIZ’s Core Philosophy: No Ads, No Interruptions</h2>
+      <p>NOIZ does not run:</p>
+      <ul>
+        <li>Pre-rolls or mid-roll ads</li>
+        <li>Banner placements or clickable pop-ups</li>
+        <li>Audio or video ads injected by third-party networks</li>
+      </ul>
+      <p>We believe that creator spaces should belong to the creator, not be hijacked by outside interests. On NOIZ, viewer attention is treated as a relationship, not an opportunity to sell impressions.</p>
+      <p>Your stream is not an ad break — it's your space.</p>
+
+      <h2 id="earn">How Creators Earn Without Ads</h2>
+      <p>NOIZ empowers creators through a support-based rewards system, not advertiser payouts.</p>
+      <p>Ways creators earn:</p>
+      <ul>
+        <li>Subscriptions — 500 dB (viewer-funded virtual support)</li>
+        <li>Tips and boosts — sent using dB and ⚡︎dB</li>
+        <li>Quest participation — creators may receive ⚡︎dB for viewer completions</li>
+        <li>Sponsored campaign quests — opt-in, brand-backed quests that reward viewers and creators</li>
+        <li>No creator needs to hit view count targets or serve ads to unlock rewards.</li>
+      </ul>
+
+      <h2 id="sponsored-quests">Sponsored Quests = Our Version of “Brand Deals”</h2>
+      <p>NOIZ uses sponsored quests as an ethical, engagement-first way to integrate brand content.</p>
+      <p>What they are:</p>
+      <ul>
+        <li>Optional Quests backed by brands or games</li>
+        <li>Viewers complete goals (e.g., "watch 15 minutes of a tagged stream")</li>
+        <li>Rewards include:
+          <ul>
+            <li>Cosmetic badges</li>
+            <li>dB</li>
+            <li>Stream-specific effects or unlockables</li>
+          </ul>
+        </li>
+      </ul>
+      <p>All sponsored quests are:</p>
+      <ul>
+        <li>Approved and reviewed by NOIZ staff</li>
+        <li>Clearly labeled with “Sponsored” tags</li>
+        <li>Built into the platform — no external signups or requirements</li>
+      </ul>
+      <p>These quests replace ad banners with something interactive and rewarding.</p>
+
+      <h2 id="why-rejected-ads">Why We Rejected Ads Entirely</h2>
+      <p>Here’s why we intentionally chose to exclude ads:</p>
+      <table>
+        <thead>
+          <tr><th>Problem With Ad-Based Platforms</th><th>NOIZ’s Response</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Viewers forced to watch irrelevant ads</td><td>No pre-rolls, no interruptions</td></tr>
+          <tr><td>Advertisers set the rules</td><td>Creators retain control</td></tr>
+          <tr><td>Metrics focused on time watched, not interaction</td><td>Boosts, quests, and chat engagement drive visibility</td></tr>
+          <tr><td>Cookie tracking and third-party surveillance</td><td>NOIZ does not use ad-tracking or sell data</td></tr>
+        </tbody>
+      </table>
+      <p>NOIZ was built for creators — not for squeezing revenue from passive watch time.</p>
+
+      <h2 id="ethical-sponsors">How Sponsored Content Stays Ethical</h2>
+      <p>We don’t just allow sponsored quests — we hold them to clear standards:</p>
+      <ul>
+        <li>All sponsored content must be tagged in-stream and in Quest UI</li>
+        <li>Rewards are always platform-native (dB, ⚡︎dB, badges — not fiat or off-site perks)</li>
+        <li>No misleading incentives or forced shoutouts</li>
+        <li>There is no pay-to-feature path — Echostage and visibility are earned through boosts and participation</li>
+        <li>Sponsored quests should feel fun, not forced.</li>
+      </ul>
+
+      <h2 id="viewer-benefits">How This Benefits Viewers</h2>
+      <p>For the audience, this means:</p>
+      <ul>
+        <li>Immediate stream access — no waiting rooms or unskippable ads</li>
+        <li>No trackers, cookies, or off-platform popups</li>
+        <li>Viewer support goes directly to creators, not intermediaries</li>
+        <li>Interactive opportunities — quests, badges, boosts — replace passive viewing</li>
+      </ul>
+      <p>The result? A cleaner, more meaningful experience for everyone.</p>
+
+      <h2 id="faq">FAQ</h2>
+      <p><strong>Q: Will NOIZ ever add ads?</strong><br>
+      A: No. NOIZ was built from the ground up to operate without them. Sponsored quests and boosts are our preferred support model.</p>
+      <p><strong>Q: Can creators add their own off-platform sponsors?</strong><br>
+      A: Yes, but disclosures are required. You must follow our <a href="#">Paid Promotions Policy</a> and clearly label sponsored content.</p>
+      <p><strong>Q: How do I sponsor a quest as a brand?</strong><br>
+      A: Contact our Partnerships Team through the <a href="#">Sponsor Portal</a>. We’ll work with you to create an ethical, action-based Quest campaign.</p>
+      <p><strong>Q: What’s the difference between a sponsored quest and a paid promotion?</strong><br>
+      A: Sponsored quests are platform-run campaigns. Paid promotions are individual creator deals and must follow proper disclosure rules.</p>
+    </article>
+  </div>
+</div>

--- a/docs/21/sidebar.html
+++ b/docs/21/sidebar.html
@@ -1,0 +1,114 @@
+<aside class="sidebar overflow-auto lg:!sticky lg:!top-[95px] lg:max-h-[calc(100vh-100px)] lg:!w-full lg:!py-10 lg:!pr-[46px]">
+  <form class="border-border mb-10 hidden w-full justify-between rounded-xl border sm:rounded-2xl lg:flex">
+    <input type="search" class="font-secondary placeholder:text-text/50 w-full border-0 bg-transparent p-3 pl-6 pr-0 placeholder:text-sm focus:border-0 focus:ring-0" data-target="search-modal" placeholder="Search The Doc">
+    <button data-target="search-modal" type="button" class="pl-3 pr-6">
+      <i class="fa-solid fa-magnifying-glass text-theme-dark"></i>
+    </button>
+  </form>
+  <ul class="sidebar-list">
+    <li data-nav-id="" title="Getting Started" class="active group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Getting Started</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/start.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="active group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/requirments/" data-accordion="">Requirments</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/installation/" data-accordion="">Installation</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/configuration/" data-accordion="">Configuration</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/customization/" data-accordion="">Customization</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/elements/" data-accordion="">Elements</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Account Bill" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Account Bill</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/bill.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/windows/" data-accordion="">Windows</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Our Features" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Our Features</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/feature.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Theme Facility" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Theme Facility</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/facility.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+  </ul>
+</aside>
+
+

--- a/docs/21/table-of-contents.html
+++ b/docs/21/table-of-contents.html
@@ -1,0 +1,24 @@
+<div class="hidden w-[350px] lg:pl-[28px] 2xl:block">
+  <div class="cs-scrollbar sticky top-[105px] hidden max-h-[calc(100vh-100px)] overflow-auto pt-10 lg:block lg:overflow-auto lg:transition-none 2xl:block">
+    <div id="toc-wrapper">
+      <div class="toc-heading">
+        <h2 class="text-h5 font-medium">Table of Contents</h2>
+      </div>
+      <nav id="TableOfContents">
+        <ol>
+          <li>
+            <ol>
+              <li><a href="#core-philosophy">NOIZ’s Core Philosophy: No Ads, No Interruptions</a></li>
+              <li><a href="#earn">How Creators Earn Without Ads</a></li>
+              <li><a href="#sponsored-quests">Sponsored Quests = Our Version of “Brand Deals”</a></li>
+              <li><a href="#why-rejected-ads">Why We Rejected Ads Entirely</a></li>
+              <li><a href="#ethical-sponsors">How Sponsored Content Stays Ethical</a></li>
+              <li><a href="#viewer-benefits">How This Benefits Viewers</a></li>
+              <li><a href="#faq">FAQ</a></li>
+            </ol>
+          </li>
+        </ol>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/docs/documents.json
+++ b/docs/documents.json
@@ -93,8 +93,8 @@
   },
   {
     "documentId": 10,
-    "title": "Earning Before Affiliate – What You Can Do",
-    "desccription": "How to earn ⚡︎dB before reaching Affiliate status.",
+    "title": "Earning Before Affiliate \u2013 What You Can Do",
+    "desccription": "How to earn \u26a1\ufe0edB before reaching Affiliate status.",
     "tags": [
       "monetization",
       "affiliate",
@@ -195,11 +195,21 @@
   {
     "documentId": 20,
     "title": "Earnings Dashboard FAQ (My Loot)",
-    "desccription": "FAQ for using the My Loot dashboard, tracking ⚡︎dB, and cashout eligibility.",
+    "desccription": "FAQ for using the My Loot dashboard, tracking \u26a1\ufe0edB, and cashout eligibility.",
     "tags": [
       "monetization",
       "dashboard",
       "faq"
+    ]
+  },
+  {
+    "documentId": 21,
+    "title": "Why NOIZ Is Ad-Free: Support-Driven Engagement & Sponsored Quests",
+    "desccription": "Explains NOIZ's ad-free model, sponsored quests, and viewer benefits.",
+    "tags": [
+      "ads",
+      "sponsorship",
+      "quests"
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- add article outlining NOIZ's ad-free philosophy, support-based monetization, and sponsored quest standards
- register the document in documents.json index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68915bbb79a083249759552367a1d087