### PR TITLE
Add Decibels token overview documentation

### DIFF
--- a/docs/22/article.html
+++ b/docs/22/article.html
@@ -1,0 +1,114 @@
+<div class="lg:w-[calc(100%-380px)] lg:border-l lg:border-l-border lg:pl-0 2xl:w-[calc(100%-380px-350px)] 2xl:pr-0 2xl:border-r 2xl:border-r-border">
+  <div class="max-w-full px-0 pt-7 lg:pt-10 lg:pl-[46px] 2xl:pr-[46px]">
+    <article class="content prose max-w-full px-0 py-0">
+      <h2 id="what-are-decibels">What Are Decibels?</h2>
+      <p><strong>Decibels (dB)</strong> are NOIZ’s <strong>official virtual support tokens</strong>, designed to power platform interactions without relying on real-world money, advertising, or cryptocurrency systems.</p>
+      <p>They are used to:</p>
+      <ul>
+        <li><strong>Support creators</strong> through actions like subscriptions, tipping, and boosts</li>
+        <li><strong>Unlock cosmetic rewards</strong> like badges, emotes, visual effects, and quests</li>
+        <li><strong>Enable platform engagement</strong> such as viewer quests, gifting, and stream boosts</li>
+      </ul>
+      <blockquote>
+        <p><strong>Important:</strong> Decibels are not a cryptocurrency, not an investment vehicle, and <strong>do not hold monetary value outside of NOIZ</strong>.</p>
+      </blockquote>
+      <p>They are designed solely for <strong>platform-contained use</strong> and <strong>reward-based interaction</strong>.</p>
+
+      <h2 id="types-of-decibels">Types of Decibels</h2>
+      <table>
+        <thead>
+          <tr><th>Token Type</th><th>Description</th><th>Can Be Cashed Out?</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>dB</code></td><td>Purchased virtual tokens, used to support creators</td><td>❌ No</td></tr>
+          <tr><td><code>⚡︎dB</code></td><td>“Charged” Decibels earned through viewer support or platform interaction</td><td>✅ Yes (if monetization requirements are met)</td></tr>
+        </tbody>
+      </table>
+      <ul>
+        <li><code>dB</code> = <strong>Faded Decibels</strong> (viewers purchase and spend them)</li>
+        <li><code>⚡︎dB</code> = <strong>Charged Decibels</strong> (creators receive them through viewer actions)</li>
+      </ul>
+      <p>Once <code>dB</code> is used to support another creator, it is transformed into <code>⚡︎dB</code> and becomes eligible for cashout <strong>if</strong> the recipient has completed platform verification and monetization requirements.</p>
+
+      <h2 id="what-can-you-do-with-decibels">What Can You Do with Decibels?</h2>
+      <h3 id="as-a-viewer">As a Viewer</h3>
+      <ul>
+        <li><strong>Subscribe</strong> to creators using 500 dB</li>
+        <li><strong>Boost</strong> a stream to help Echostage visibility</li>
+        <li><strong>Gift</strong> subs to other viewers</li>
+        <li><strong>Complete quests</strong> (some may require dB contributions)</li>
+        <li><strong>Unlock cosmetic items or rewards</strong> via in-platform listings</li>
+      </ul>
+      <h3 id="as-a-creator-streamer-artist-developer">As a Creator (Streamer / Artist / Developer)</h3>
+      <ul>
+        <li><strong>Receive ⚡︎dB</strong> from viewer support (subs, boosts, quests, plugin usage)</li>
+        <li><strong>Redeem ⚡︎dB</strong> once eligible (Affiliate level, 10,000 ⚡︎dB minimum)</li>
+        <li><strong>Use your dB or ⚡︎dB</strong> to support other creators, participate in quests, or unlock features</li>
+      </ul>
+
+      <h2 id="how-supply-works">How Supply Works</h2>
+      <p>Unlike cryptocurrencies, NOIZ <strong>does not use a decentralized minting process</strong>. All Decibel supply is <strong>centrally controlled</strong> to maintain legal compliance and platform integrity.</p>
+      <p><strong>dB:</strong></p>
+      <ul>
+        <li>Created when a user <strong>purchases them via Constellation</strong></li>
+        <li>Marked as “faded” and cannot be withdrawn</li>
+        <li>Non-refundable once used for support</li>
+      </ul>
+      <p><strong>⚡︎dB:</strong></p>
+      <ul>
+        <li>Created when dB is used <strong>to support a creator</strong></li>
+        <li>Assigned to that creator’s account as <strong>Charged Decibels</strong></li>
+        <li>Can be <strong>cashed out</strong> only if the creator is eligible (Affiliate+, verified, and over 10,000 ⚡︎dB)</li>
+      </ul>
+      <p>If support activity is found to be fraudulent (e.g., self-tipping or bot abuse), ⚡︎dB may be <strong>flagged and removed</strong>.</p>
+
+      <h2 id="how-decibels-stay-balanced">How Decibels Stay Balanced</h2>
+      <p>There is no finite “total supply” of Decibels. Instead, the system is <strong>usage-based</strong> and <strong>regulated internally</strong>:</p>
+      <ul>
+        <li>The platform mints new dB only when <strong>purchases occur</strong></li>
+        <li><code>⚡︎dB</code> is <strong>earned, not bought</strong>, ensuring it flows through genuine engagement</li>
+        <li>Token flow is <strong>tracked and monitored</strong> to prevent abuse</li>
+        <li>System-wide support budgets (e.g., for Pathweavers or campaign rewards) are distributed carefully and reviewed</li>
+      </ul>
+      <p>NOIZ adjusts platform-wide variables such as:</p>
+      <ul>
+        <li>Revenue splits</li>
+        <li>Quest rewards</li>
+        <li>Campaign pools</li>
+        <li>Asset pricing</li>
+      </ul>
+      <blockquote>
+        <p>The system is designed to scale and balance — not inflate or dilute value.</p>
+      </blockquote>
+
+      <h2 id="why-we-dont-call-it-a-coin">Why We Don’t Call It a Coin</h2>
+      <p>To ensure <strong>clarity and legal safety</strong>, Decibels are <strong>never referred to as coins, tokens of value, or crypto</strong>.</p>
+      <p>Decibels are:</p>
+      <ul>
+        <li><strong>Not speculative assets</strong> — their value is fixed and cannot be traded</li>
+        <li><strong>Not transferable off-platform</strong> — they remain inside NOIZ</li>
+        <li><strong>Not backed by fiat or blockchain</strong> — there is no mining, staking, or volatility</li>
+        <li><strong>Not designed for resale</strong> — they cannot be sold, exchanged, or liquidated outside of NOIZ’s internal system</li>
+      </ul>
+      <p>They’re best understood as <strong>platform-locked digital goods</strong> — like Twitch Bits, Robux, or V-Bucks — but with clearer distinction between spendable (<code>dB</code>) and earnable (<code>⚡︎dB</code>) types.</p>
+
+      <h2 id="key-principles">Key Principles</h2>
+      <ul>
+        <li>🔁 <strong>No Decibel can be cashed out unless it’s charged (<code>⚡︎dB</code>)</strong></li>
+        <li>👥 <strong>No Decibel is earned without viewer or user support</strong></li>
+        <li>🌐 <strong>No Decibel can leave the platform</strong> — there is no crypto bridge, no resale path, no wallet-to-wallet transfer</li>
+      </ul>
+      <p>This protects the platform from financial classification issues and ensures creators are rewarded for meaningful contribution — not speculative schemes.</p>
+
+      <h2 id="faq">FAQ</h2>
+      <p><strong>Q: Can I trade Decibels with other users?</strong><br>
+      A: No. Decibels cannot be transferred directly between users, and there is no trading system.</p>
+      <p><strong>Q: Can Decibels ever become cryptocurrency?</strong><br>
+      A: No. Decibels are not based on blockchain and are intentionally kept off-chain to avoid regulatory issues.</p>
+      <p><strong>Q: Will the cost of dB change over time?</strong><br>
+      A: dB pricing may adjust platform-wide based on economic needs, but the core value of <code>⚡︎dB</code> will remain stable for creator rewards.</p>
+      <p><strong>Q: What happens to unused Decibels?</strong><br>
+      A: Unused dB remain in the user’s Constellation ledger until spent. They are not refundable, but they do not expire.</p>
+    </article>
+  </div>
+</div>

--- a/docs/22/sidebar.html
+++ b/docs/22/sidebar.html
@@ -1,0 +1,114 @@
+<aside class="sidebar overflow-auto lg:!sticky lg:!top-[95px] lg:max-h-[calc(100vh-100px)] lg:!w-full lg:!py-10 lg:!pr-[46px]">
+  <form class="border-border mb-10 hidden w-full justify-between rounded-xl border sm:rounded-2xl lg:flex">
+    <input type="search" class="font-secondary placeholder:text-text/50 w-full border-0 bg-transparent p-3 pl-6 pr-0 placeholder:text-sm focus:border-0 focus:ring-0" data-target="search-modal" placeholder="Search The Doc">
+    <button data-target="search-modal" type="button" class="pl-3 pr-6">
+      <i class="fa-solid fa-magnifying-glass text-theme-dark"></i>
+    </button>
+  </form>
+  <ul class="sidebar-list">
+    <li data-nav-id="" title="Getting Started" class="active group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Getting Started</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/start.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="active group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/requirments/" data-accordion="">Requirments</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/installation/" data-accordion="">Installation</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/configuration/" data-accordion="">Configuration</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/customization/" data-accordion="">Customization</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/elements/" data-accordion="">Elements</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Account Bill" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Account Bill</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/bill.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/windows/" data-accordion="">Windows</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Our Features" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Our Features</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/feature.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Theme Facility" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Theme Facility</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/facility.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+  </ul>
+</aside>
+
+

--- a/docs/22/table-of-contents.html
+++ b/docs/22/table-of-contents.html
@@ -1,0 +1,30 @@
+<div class="hidden w-[350px] lg:pl-[28px] 2xl:block">
+  <div class="cs-scrollbar sticky top-[105px] hidden max-h-[calc(100vh-100px)] overflow-auto pt-10 lg:block lg:overflow-auto lg:transition-none 2xl:block">
+    <div id="toc-wrapper">
+      <div class="toc-heading">
+        <h2 class="text-h5 font-medium">Table of Contents</h2>
+      </div>
+      <nav id="TableOfContents">
+        <ol>
+          <li>
+            <ol>
+              <li><a href="#what-are-decibels">What Are Decibels?</a></li>
+              <li><a href="#types-of-decibels">Types of Decibels</a></li>
+              <li><a href="#what-can-you-do-with-decibels">What Can You Do with Decibels?</a>
+                <ol>
+                  <li><a href="#as-a-viewer">As a Viewer</a></li>
+                  <li><a href="#as-a-creator-streamer-artist-developer">As a Creator (Streamer / Artist / Developer)</a></li>
+                </ol>
+              </li>
+              <li><a href="#how-supply-works">How Supply Works</a></li>
+              <li><a href="#how-decibels-stay-balanced">How Decibels Stay Balanced</a></li>
+              <li><a href="#why-we-dont-call-it-a-coin">Why We Don’t Call It a Coin</a></li>
+              <li><a href="#key-principles">Key Principles</a></li>
+              <li><a href="#faq">FAQ</a></li>
+            </ol>
+          </li>
+        </ol>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/docs/documents.json
+++ b/docs/documents.json
@@ -211,5 +211,15 @@
       "sponsorship",
       "quests"
     ]
+  },
+  {
+    "documentId": 22,
+    "title": "Decibels Token Overview: Uses, Supply, and Utility",
+    "desccription": "Overview of Decibel token types, supply management, and platform utility.",
+    "tags": [
+      "db",
+      "tokens",
+      "support"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- document Decibels virtual support tokens, outlining dB vs ⚡︎dB types, usage, and platform controls.
- include table of contents and sidebar for new Decibels token doc.
- register the Decibels overview in `documents.json`.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68915ec53d5c8324be358455a21e1358