### PR TITLE
Add mature content policy document

### DIFF
--- a/docs/36/article.html
+++ b/docs/36/article.html
@@ -1,0 +1,112 @@
+<div class="lg:w-[calc(100%-380px)] lg:border-l lg:border-l-border lg:pl-0 2xl:w-[calc(100%-380px-350px)] 2xl:pr-0 2xl:border-r 2xl:border-r-border">
+  <div class="max-w-full px-0 pt-7 lg:pt-10 lg:pl-[46px] 2xl:pr-[46px]">
+    <article class="content prose max-w-full px-0 py-0">
+      <h2 id="what-counts-as-mature-content">1. What Counts as Mature Content</h2>
+      <p>Mature content refers to any stream element that may not be appropriate for all audiences, including:</p>
+      <ul>
+        <li>Profanity, vulgar language, or graphic jokes</li>
+        <li>Explicit or heavy thematic content (e.g. sex, trauma, violence, gore)</li>
+        <li>Depictions or discussion of alcohol, drugs, or tobacco</li>
+        <li>Mature-rated games with blood, horror, or suggestive content</li>
+        <li>Innuendo or lewd humor (without being sexually explicit)</li>
+      </ul>
+      <blockquote>
+        <p><strong>Mature does not mean adult entertainment.</strong> Content should still serve a creative, narrative, or expressive purpose — not exist solely for shock or sexual provocation.</p>
+      </blockquote>
+
+      <h2 id="what-s-allowed-with-a-mature-label">2. What’s Allowed with a Mature Label</h2>
+      <p>You may stream the following, if properly labeled:</p>
+      <ul>
+        <li>Games rated <strong>Mature</strong> or <strong>18+</strong>, including horror, FPS, or survival titles</li>
+        <li>IRL conversations involving adult themes or lived experience (e.g., relationships, nightlife, trauma)</li>
+        <li>Casual use of swearing, crude jokes, or adult-oriented humor</li>
+        <li>References to drinking, smoking, or partying in a storytelling context</li>
+      </ul>
+      <p>If your stream includes any of the above, you must use:</p>
+      <ul>
+        <li>The <strong>"Mature" tag</strong></li>
+        <li>A stream rating of <strong>M</strong> or <strong>18+</strong></li>
+        <li>Let NOIZ’s <strong>auto age-gating</strong> apply</li>
+      </ul>
+      <blockquote>
+        <p>Tags and ratings are not optional — they’re required for both viewer safety and legal compliance.</p>
+      </blockquote>
+
+      <h2 id="what-is-not-allowed-even-with-a-mature-tag">3. What Is Not Allowed — Even With a Mature Tag</h2>
+      <p>The following are strictly prohibited, regardless of maturity rating or stream context:</p>
+      <ul>
+        <li>Pornographic content (live, pre-recorded, or animated)</li>
+        <li>Nudity, sexual activity, or simulation of sexual acts</li>
+        <li>Depictions of minors in any sexual or suggestive context (zero tolerance)</li>
+        <li>Real-world violence (e.g., fights, injury stunts, accidents)</li>
+        <li>Promotion of illegal behavior (e.g., drug use on camera, reckless dares)</li>
+        <li>Streams whose primary focus is sexual content or titillation</li>
+      </ul>
+      <blockquote>
+        <p><strong>NOIZ is not an adult content platform.</strong> Mature tags are for thematic or expressive context — not a license to break ToS.</p>
+      </blockquote>
+
+      <h2 id="special-cases">4. Special Cases</h2>
+      <table>
+        <thead>
+          <tr><th>Content Type</th><th>Policy</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><strong>Bath/hot tub</strong></td><td>Allowed only if the context is non-sexual. Swimwear must follow clothing policy.</td></tr>
+          <tr><td><strong>Body painting</strong></td><td>Permitted as art if covered with ToS-compliant garments and clearly tagged.</td></tr>
+          <tr><td><strong>IRL nightlife</strong></td><td>Allowed with proper tags. No excessive intoxication or lewd behavior.</td></tr>
+          <tr><td><strong>Dark games</strong></td><td>Allowed — but disturbing content must be rated and tagged accordingly.</td></tr>
+        </tbody>
+      </table>
+      <p>NOIZ recognizes that context matters — but intent and tone are also reviewed during moderation.</p>
+
+      <h2 id="creator-responsibilities">5. Creator Responsibilities</h2>
+      <p>As a creator, you are responsible for:</p>
+      <ul>
+        <li>Applying the correct stream rating and mature tags before going live</li>
+        <li>Updating the tags if your stream changes tone or content mid-session</li>
+        <li>Using overlays or chat descriptions to clarify what viewers can expect</li>
+        <li>Moderating your chat to prevent viewer behavior from becoming inappropriate or harassing</li>
+      </ul>
+      <blockquote>
+        <p>Mature doesn’t mean “anything goes.” Respectful boundaries still apply — for both the content and the community around it.</p>
+      </blockquote>
+
+      <h2 id="viewer-protections">6. Viewer Protections</h2>
+      <p>Mature content is automatically:</p>
+      <ul>
+        <li><strong>Age-gated</strong> using Constellation-linked birthdate</li>
+        <li><strong>Hidden</strong> from underage viewers and searchable filters (based on settings)</li>
+        <li><strong>Flagged</strong> with a “Mature Content” warning before the stream can be entered</li>
+      </ul>
+      <p>Viewers can also:</p>
+      <ul>
+        <li>Disable all mature stream visibility in their Settings</li>
+        <li>Report miscategorized streams that appear to bypass content policies</li>
+      </ul>
+      <blockquote>
+        <p>If a stream isn’t properly tagged, you can help keep the platform safe by reporting it.</p>
+      </blockquote>
+
+      <h2 id="violations-and-enforcement">7. Violations and Enforcement</h2>
+      <p>Failing to follow mature content rules can lead to:</p>
+      <ul>
+        <li>Content flagging and visibility restrictions</li>
+        <li>Warnings or temporary suspension for misleading tags or misratings</li>
+        <li>Immediate ban and Staff Admin escalation for sexual exploitation, predatory behavior, or repeat violations</li>
+      </ul>
+      <p>NOIZ reserves the right to:</p>
+      <ul>
+        <li>Mute or remove streams retroactively</li>
+        <li>Flag channels for maturity non-compliance</li>
+        <li>Enforce stricter controls for repeat offenders</li>
+      </ul>
+
+      <h2 id="faq">8. FAQ</h2>
+      <p><strong>Can I stream an M-rated game without a mature tag?</strong><br>No — any game rated M or containing frequent violence or adult content must be labeled.</p>
+      <p><strong>Is cosplay or themed attire allowed on a mature stream?</strong><br>Yes, if it complies with the Clothing &amp; Expression Policy and is not sexually explicit.</p>
+      <p><strong>What if my chat is mature but the game isn’t?</strong><br>You still need to tag your stream if the discussion or tone is adult in nature.</p>
+      <p><strong>How do I get my stream reclassified if it was flagged incorrectly?</strong><br>Use the appeal tool under <code>Creator Dashboard → Content Flag → Request Review</code>.</p>
+    </article>
+  </div>
+</div>

--- a/docs/36/sidebar.html
+++ b/docs/36/sidebar.html
@@ -1,0 +1,114 @@
+<aside class="sidebar overflow-auto lg:!sticky lg:!top-[95px] lg:max-h-[calc(100vh-100px)] lg:!w-full lg:!py-10 lg:!pr-[46px]">
+  <form class="border-border mb-10 hidden w-full justify-between rounded-xl border sm:rounded-2xl lg:flex">
+    <input type="search" class="font-secondary placeholder:text-text/50 w-full border-0 bg-transparent p-3 pl-6 pr-0 placeholder:text-sm focus:border-0 focus:ring-0" data-target="search-modal" placeholder="Search The Doc">
+    <button data-target="search-modal" type="button" class="pl-3 pr-6">
+      <i class="fa-solid fa-magnifying-glass text-theme-dark"></i>
+    </button>
+  </form>
+  <ul class="sidebar-list">
+    <li data-nav-id="" title="Getting Started" class="active group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Getting Started</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/start.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="active group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/requirments/" data-accordion="">Requirments</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/installation/" data-accordion="">Installation</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/configuration/" data-accordion="">Configuration</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/customization/" data-accordion="">Customization</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/elements/" data-accordion="">Elements</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Account Bill" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Account Bill</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/bill.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/windows/" data-accordion="">Windows</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Our Features" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Our Features</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/feature.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Theme Facility" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Theme Facility</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/facility.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+  </ul>
+</aside>
+
+

--- a/docs/36/table-of-contents.html
+++ b/docs/36/table-of-contents.html
@@ -1,0 +1,25 @@
+<div class="hidden w-[350px] lg:pl-[28px] 2xl:block">
+  <div class="cs-scrollbar sticky top-[105px] hidden max-h-[calc(100vh-100px)] overflow-auto pt-10 lg:block lg:overflow-auto lg:transition-none 2xl:block">
+    <div id="toc-wrapper">
+      <div class="toc-heading">
+        <h2 class="text-h5 font-medium">Table of Contents</h2>
+      </div>
+      <nav id="TableOfContents">
+        <ol>
+          <li>
+            <ol>
+              <li><a href="#what-counts-as-mature-content">1. What Counts as Mature Content</a></li>
+              <li><a href="#what-s-allowed-with-a-mature-label">2. What’s Allowed with a Mature Label</a></li>
+              <li><a href="#what-is-not-allowed-even-with-a-mature-tag">3. What Is Not Allowed — Even With a Mature Tag</a></li>
+              <li><a href="#special-cases">4. Special Cases</a></li>
+              <li><a href="#creator-responsibilities">5. Creator Responsibilities</a></li>
+              <li><a href="#viewer-protections">6. Viewer Protections</a></li>
+              <li><a href="#violations-and-enforcement">7. Violations and Enforcement</a></li>
+              <li><a href="#faq">8. FAQ</a></li>
+            </ol>
+          </li>
+        </ol>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/docs/documents.json
+++ b/docs/documents.json
@@ -93,8 +93,8 @@
   },
   {
     "documentId": 10,
-    "title": "Earning Before Affiliate \u2013 What You Can Do",
-    "desccription": "How to earn \u26a1\ufe0edB before reaching Affiliate status.",
+    "title": "Earning Before Affiliate – What You Can Do",
+    "desccription": "How to earn ⚡︎dB before reaching Affiliate status.",
     "tags": [
       "monetization",
       "affiliate",
@@ -195,7 +195,7 @@
   {
     "documentId": 20,
     "title": "Earnings Dashboard FAQ (My Loot)",
-    "desccription": "FAQ for using the My Loot dashboard, tracking \u26a1\ufe0edB, and cashout eligibility.",
+    "desccription": "FAQ for using the My Loot dashboard, tracking ⚡︎dB, and cashout eligibility.",
     "tags": [
       "monetization",
       "dashboard",
@@ -225,7 +225,7 @@
   {
     "documentId": 23,
     "title": "Constellation Linking, Custody, and Withdrawals",
-    "desccription": "How Constellation handles account linking, Decibel custody, and \u26a1\ufe0edB withdrawals.",
+    "desccription": "How Constellation handles account linking, Decibel custody, and ⚡︎dB withdrawals.",
     "tags": [
       "constellation",
       "db",
@@ -353,6 +353,16 @@
       "legal",
       "compliance",
       "streaming"
+    ]
+  },
+  {
+    "documentId": 36,
+    "title": "Mature Content Policy",
+    "desccription": "Guidelines for labeling and handling mature content on NOIZ streams.",
+    "tags": [
+      "policy",
+      "content",
+      "mature"
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- add Mature Content Policy guide covering allowed mature themes, prohibitions, responsibilities, and viewer protections
- register Mature Content Policy in documents listing

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689278c736b88324990b8256ace82dee