### PR TITLE
docs: expand viewer quest FAQ with hype moments

### DIFF
--- a/docs/66/article.html
+++ b/docs/66/article.html
@@ -17,32 +17,32 @@
         <li>Streamer campaigns</li>
         <li>Platform-wide engagement goals</li>
       </ul>
-      <p>You don’t need to stream — just watch, chat, and interact.</p>
+      <blockquote>You don’t need to stream — just watch, chat, and interact.</blockquote>
       <hr>
       <h2 id="2-how-do-i-join-a-quest">2. How Do I Join a Quest?</h2>
-      <ol>
+      <ul>
         <li>Visit a participating stream</li>
         <li>Click the <strong>Quest Tracker</strong> icon in the stream HUD</li>
         <li>If the streamer is enrolled in a Quest, you’ll see the objectives</li>
         <li>Click <strong>Join Quest</strong> (if required)</li>
         <li>Your progress updates in real time</li>
-      </ol>
-      <blockquote>You must be logged in with your Constellation-linked account to track progress.</blockquote>
+      </ul>
+      <p>You must be logged in with your Constellation-linked account to track progress.</p>
       <hr>
       <h2 id="3-what-counts-toward-completion">3. What Counts Toward Completion?</h2>
-      <p>Depends on the quest, but typically includes:</p>
+      <p>Depends on the quest — but typically includes:</p>
       <p><strong>✅ Tracked viewer actions:</strong></p>
       <ul>
         <li>Watch time while not muted and actively focused (no background tabs)</li>
         <li>Chat participation (not spam)</li>
-        <li>⚡️Decibel support (tips or subs)</li>
+        <li>⚡︎ dB support (tips or subs)</li>
         <li>Emote or reaction use</li>
         <li>Plugin interaction (polls, click-to-reveal, buttons)</li>
       </ul>
-      <blockquote>↺ Some quests reset daily or weekly — others are one-time.</blockquote>
+      <p>↺ Some quests reset daily or weekly — others are one-time.</p>
       <hr>
       <h2 id="4-what-doesnt-count">4. What Doesn’t Count</h2>
-      <p><strong>🚫 Actions that will not progress your quest:</strong></p>
+      <p><strong>❌ Actions that will not progress your quest:</strong></p>
       <ul>
         <li>Muted streams</li>
         <li>Watching from an embed without interaction</li>
@@ -50,10 +50,10 @@
         <li>Bot-like activity (e.g., repeating chat spam or macro emotes)</li>
         <li>Using alternate accounts or VPN to double-complete</li>
       </ul>
-      <blockquote>Violation of quest rules may result in:</blockquote>
+      <p>Violation of quest rules may result in:</p>
       <ul>
         <li>Progress wipe</li>
-        <li>⚡️Decibel reversal</li>
+        <li>⚡︎ dB reversal</li>
         <li>Viewer cooldown or shadowmute on quest systems</li>
       </ul>
       <hr>
@@ -61,20 +61,20 @@
       <p>You’ll see:</p>
       <ul>
         <li>✅ A completion checkmark on the Quest Tracker</li>
-        <li>🌱 Reward claim screen (with optional visual unlock animation)</li>
+        <li>🏱 Reward claim screen (with optional visual unlock animation)</li>
         <li>📩 A system notification in your Quest Log or inbox</li>
+        <li>(Optional) Claim prompts for marketplace items or emotes</li>
       </ul>
-      <blockquote>(Optional) Claim prompts for marketplace items or emotes</blockquote>
       <hr>
       <h2 id="6-where-are-my-rewards-stored">6. Where Are My Rewards Stored?</h2>
       <p>Rewards are deposited to:</p>
       <ul>
-        <li>⚡️Decibel balance (for charged Decibels)</li>
+        <li>⚡︎ dB balance (for charged Decibels)</li>
         <li>Your Reverb total (channel interaction points)</li>
         <li>Your <strong>Marketplace Locker</strong> (for emotes, badges, assets)</li>
         <li>Your <strong>Profile Inventory</strong> (for collectible rewards)</li>
       </ul>
-      <p>Some rewards unlock instantly, while others may be claimable later.</p>
+      <blockquote>Some rewards unlock instantly, while others may be claimable later.</blockquote>
       <hr>
       <h2 id="7-how-do-i-track-my-progress">7. How Do I Track My Progress?</h2>
       <p>You can:</p>
@@ -94,6 +94,76 @@
       <blockquote>Yes, if the quest includes a clip objective</blockquote>
       <p><strong>Will I lose progress if the stream crashes?</strong></p>
       <blockquote>No — partial credit is saved live</blockquote>
+      <hr>
+      <h2 id="what-are-hype-moments-boosts-what-triggers-them">⚡︎ What Are Hype Moments &amp; Boosts: What Triggers Them?</h2>
+      <h3 id="1-what-is-a-hype-moment-on-noiz">1. What Is a Hype Moment on NOIZ?</h3>
+      <p>A Hype Moment is an automatically detected or manually triggered spike in stream energy. These moments highlight:</p>
+      <ul>
+        <li>Sudden viewer reactions (chat spikes, emotes, Vibes)</li>
+        <li>Clippable gameplay events (boss kills, wins, fails, etc.)</li>
+        <li>Surges in ⚡︎ dB tips or gifted subs</li>
+        <li>Quest completions or plugin milestones</li>
+      </ul>
+      <p>They act as momentary signal boosts to:</p>
+      <ul>
+        <li>Launch clips into trending rotation</li>
+        <li>Temporarily increase Echostage eligibility</li>
+        <li>Show visual “surge” overlays (e.g., chat glow, emote explosions)</li>
+      </ul>
+      <blockquote>Think of it as a “mini spotlight” for what’s happening right now.</blockquote>
+      <hr>
+      <h3 id="2-what-triggers-a-hype-moment">2. What Triggers a Hype Moment?</h3>
+      <p>It can happen in a few ways:</p>
+      <p><strong>🔁 Auto-Triggered:</strong></p>
+      <ul>
+        <li>Large spike in chat activity or Vibe usage within 10s</li>
+        <li>Major gameplay milestone detected via plugin (e.g. kill cam, speedrun split)</li>
+        <li>Multiple tips or subs within a short burst</li>
+        <li>Viewer milestone unlock (e.g. 1M Vibes reached)</li>
+      </ul>
+      <p><strong>● Manually Triggered:</strong></p>
+      <ul>
+        <li>Streamer hits the “Mark Hype” button from their dashboard or stream deck</li>
+        <li>Editor or mod flags a Hype clip during live review</li>
+        <li>Clip submissions with rapid upvotes or reactions</li>
+      </ul>
+      <hr>
+      <h3 id="3-what-happens-during-a-hype-moment">3. What Happens During a Hype Moment?</h3>
+      <p>When active:</p>
+      <ul>
+        <li>A small on-screen banner appears (“HYPE INCOMING” or custom variant)</li>
+        <li>Plugins may pulse, animate, or glow</li>
+        <li>Echostage may temporarily prioritize your stream</li>
+        <li>The moment is automatically clipped for streamer and viewers</li>
+        <li>Boosted discoverability in Quest or Clip feeds</li>
+      </ul>
+      <blockquote>It lasts ~10–15 seconds and doesn’t interrupt gameplay.</blockquote>
+      <hr>
+      <h3 id="4-streamer-tools-for-hype">4. Streamer Tools for Hype</h3>
+      <ul>
+        <li>Enable/disable auto-detection from <strong>Stream Settings → Hype Detection</strong></li>
+        <li>Customize overlay behavior, clip length, and sound effects</li>
+        <li>Grant permission to mods to mark hype manually</li>
+        <li>Review all triggered moments in <strong>Dashboard → Hype Log</strong></li>
+      </ul>
+      <hr>
+      <h3 id="5-best-practices">5. Best Practices</h3>
+      <ul>
+        <li>✅ Encourage viewers to react during high-stakes or emotional moments</li>
+        <li>✅ Use overlays or chat pings to recognize a Hype burst</li>
+        <li>✅ Incorporate into Quests ("Trigger X Hype Moments this week")</li>
+        <li>✅ Use Hype Moments as a call to clip, follow, or gift subs</li>
+      </ul>
+      <hr>
+      <h3 id="6-faq">6. FAQ</h3>
+      <p><strong>Can I fake a Hype Moment?</strong></p>
+      <blockquote>No — artificial triggers may be filtered or penalized</blockquote>
+      <p><strong>Can I disable this feature?</strong></p>
+      <blockquote>Yes — entirely or selectively</blockquote>
+      <p><strong>Do Hype Moments help me get on Echostage?</strong></p>
+      <blockquote>Yes — they increase visibility weighting, especially when combined with retention</blockquote>
+      <p><strong>Can Hype Moments be turned into Quest objectives?</strong></p>
+      <blockquote>Yes — by platform or sponsor</blockquote>
     </article>
   </div>
 </div>

--- a/docs/66/table-of-contents.html
+++ b/docs/66/table-of-contents.html
@@ -16,6 +16,16 @@
               <li><a href="#6-where-are-my-rewards-stored">6. Where Are My Rewards Stored?</a></li>
               <li><a href="#7-how-do-i-track-my-progress">7. How Do I Track My Progress?</a></li>
               <li><a href="#8-faq">8. FAQ</a></li>
+              <li><a href="#what-are-hype-moments-boosts-what-triggers-them">⚡︎ What Are Hype Moments &amp; Boosts: What Triggers Them?</a>
+                <ol>
+                  <li><a href="#1-what-is-a-hype-moment-on-noiz">1. What Is a Hype Moment on NOIZ?</a></li>
+                  <li><a href="#2-what-triggers-a-hype-moment">2. What Triggers a Hype Moment?</a></li>
+                  <li><a href="#3-what-happens-during-a-hype-moment">3. What Happens During a Hype Moment?</a></li>
+                  <li><a href="#4-streamer-tools-for-hype">4. Streamer Tools for Hype</a></li>
+                  <li><a href="#5-best-practices">5. Best Practices</a></li>
+                  <li><a href="#6-faq">6. FAQ</a></li>
+                </ol>
+              </li>
             </ol>
           </li>
         </ol>

--- a/docs/documents.json
+++ b/docs/documents.json
@@ -661,11 +661,13 @@
   {
     "documentId": 66,
     "title": "Viewer Quest Completion FAQ",
-    "desccription": "How viewer quests work, joining, progress tracking, and rewards.",
+    "desccription": "How viewer quests work, joining, progress tracking, rewards, and Hype Moments.",
     "tags": [
       "quests",
       "viewer",
-      "faq"
+      "faq",
+      "hype",
+      "boosts"
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- refresh viewer quest completion FAQ with updated dB terminology and reward claim details
- introduce Hype Moments & Boosts section outlining triggers, behavior, and best practices
- tag documentation entry for hype moments in documents.json

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68950e74335083249c058063c521a65a