### PR TITLE
Add overlay and tool management documentation

### DIFF
--- a/docs/68/article.html
+++ b/docs/68/article.html
@@ -1,0 +1,93 @@
+<div class="lg:w-[calc(100%-380px)] lg:border-l lg:border-l-border lg:pl-0 2xl:w-[calc(100%-380px-350px)] 2xl:pr-0 2xl:border-r 2xl:border-r-border">
+  <div class="max-w-full px-0 pt-7 lg:pt-10 lg:pl-[46px] 2xl:pr-[46px]">
+    <article class="content prose max-w-full px-0 py-0">
+      <blockquote>Overlays and tools on NOIZ add visual flair and interactivity to your stream and can be installed or managed directly in NOIZ Studio or OBS.</blockquote>
+
+      <h2 id="1-what-are-overlays-and-stream-tools">1. What Are Overlays and Stream Tools?</h2>
+      <p>On NOIZ, overlays and tools are modular assets that enhance the visual, informational, or interactive experience of a stream. These include:</p>
+      <ul>
+        <li>Camera borders, stingers, alert boxes</li>
+        <li>Plugin-driven tools (timers, hype trackers, emote bursts)</li>
+        <li>Custom scenes or transition packs</li>
+        <li>Marketplace-installed assets or personal uploads</li>
+      </ul>
+      <p>They can be:</p>
+      <ul>
+        <li>Imported directly into NOIZ Studio or OBS</li>
+        <li>Managed through the Plugin Manager or Scene Layout Editor</li>
+      </ul>
+
+      <h2 id="2-how-to-install-overlays-from-the-marketplace">2. How to Install Overlays from the Marketplace</h2>
+      <ol>
+        <li>Visit the <strong>Marketplace</strong> → <strong>Overlay Packs</strong></li>
+        <li>Choose a pack or tool labeled:
+          <ul>
+            <li><em>NOIZ Studio Compatible</em></li>
+            <li><em>OBS Import Bundle</em></li>
+          </ul>
+        </li>
+        <li>Click <strong>"Add to My Assets"</strong> or <strong>"Install Now"</strong></li>
+        <li>Open <strong>NOIZ Studio</strong> → <strong>Assets</strong> to find your new overlays</li>
+        <li>Drag-and-drop into your active scene or scene list</li>
+      </ol>
+      <p>Overlays may also come with <code>.overlay</code>, <code>.json</code>, or <code>.npk</code> config files for faster setup.</p>
+
+      <h2 id="3-managing-overlays-in-noiz-studio">3. Managing Overlays in NOIZ Studio</h2>
+      <p>In <strong>NOIZ Studio</strong>:</p>
+      <ul>
+        <li>Use the <strong>Layout Panel</strong> to add/remove visual elements</li>
+        <li>Layer items by drag-and-drop</li>
+        <li>Lock positioning for screen-safe zones</li>
+        <li>Toggle overlays per scene or profile</li>
+        <li>Preview <strong>mobile vs desktop</strong> stream layout</li>
+      </ul>
+      <p>You can also:</p>
+      <ul>
+        <li>Bind overlays to plugin events (e.g. emote rain after sub)</li>
+        <li>Adjust <strong>opacity, size, and animation timing</strong></li>
+        <li>Group overlays into a reusable <strong>Scene Template</strong></li>
+      </ul>
+
+      <h2 id="4-custom-overlay-uploads">4. Custom Overlay Uploads</h2>
+      <p>✅ You can upload your own assets:</p>
+      <ul>
+        <li>Static PNG/JPEG overlays</li>
+        <li>Transparent WebM animations</li>
+        <li>Lottie files for lightweight vector effects</li>
+        <li>Custom plugin graphics or stream borders</li>
+      </ul>
+      <p>To upload:<br><strong>Dashboard → Creator Tools → Upload Overlay</strong></p>
+      <p>You can categorize by:</p>
+      <ul>
+        <li><strong>Scene type</strong> (BRB, Live, Starting Soon)</li>
+        <li><strong>Feature</strong> (Alert, Frame, Tracker)</li>
+        <li><strong>Source</strong> (Self-made, Commissioned, Purchased)</li>
+      </ul>
+
+      <h2 id="5-linking-overlays-with-plugins">5. Linking Overlays with Plugins</h2>
+      <p>Some overlays are plugin-reactive:</p>
+      <ul>
+        <li>Change appearance when a sub or ⚡︎dB tip occurs</li>
+        <li>Visually track Quest completion</li>
+        <li>Trigger when a Hype Moment is detected</li>
+        <li>Allow viewer reactions to affect visual effects</li>
+      </ul>
+      <p>These can be configured under:<br><strong>Dashboard → Plugins → Overlay Triggers</strong></p>
+
+      <h2 id="6-performance-and-compatibility">6. Performance &amp; Compatibility</h2>
+      <p>Overlays are rendered client-side for viewers. Tips to optimize:</p>
+      <ul>
+        <li>Limit simultaneous WebM animations to &lt;3 on low-end systems</li>
+        <li>Avoid 4K overlays unless your stream targets high-spec playback</li>
+        <li>Use overlay presets tested with NOIZ Studio or OBS 29+</li>
+        <li>Keep total overlay file size under 25MB per scene for mobile compatibility</li>
+      </ul>
+
+      <h2 id="7-faq">7. FAQ</h2>
+      <p><strong>Can I sell overlays on the Marketplace?</strong><br>→ Yes, if you’re a Verified Artist</p>
+      <p><strong>Can I import Twitch or Streamlabs overlays?</strong><br>→ Not directly, but you can repackage the assets</p>
+      <p><strong>Can overlays use audio?</strong><br>→ Yes — with autoplay disabled and viewer opt-in</p>
+      <p><strong>Do overlays affect latency?</strong><br>→ No — they’re optimized and rendered separately from your video feed</p>
+    </article>
+  </div>
+</div>

--- a/docs/68/sidebar.html
+++ b/docs/68/sidebar.html
@@ -1,0 +1,114 @@
+<aside class="sidebar overflow-auto lg:!sticky lg:!top-[95px] lg:max-h-[calc(100vh-100px)] lg:!w-full lg:!py-10 lg:!pr-[46px]">
+  <form class="border-border mb-10 hidden w-full justify-between rounded-xl border sm:rounded-2xl lg:flex">
+    <input type="search" class="font-secondary placeholder:text-text/50 w-full border-0 bg-transparent p-3 pl-6 pr-0 placeholder:text-sm focus:border-0 focus:ring-0" data-target="search-modal" placeholder="Search The Doc">
+    <button data-target="search-modal" type="button" class="pl-3 pr-6">
+      <i class="fa-solid fa-magnifying-glass text-theme-dark"></i>
+    </button>
+  </form>
+  <ul class="sidebar-list">
+    <li data-nav-id="" title="Getting Started" class="active group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Getting Started</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/start.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="active group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/requirments/" data-accordion="">Requirments</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/installation/" data-accordion="">Installation</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/configuration/" data-accordion="">Configuration</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/customization/" data-accordion="">Customization</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/elements/" data-accordion="">Elements</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Account Bill" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Account Bill</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/bill.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/windows/" data-accordion="">Windows</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Our Features" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Our Features</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/feature.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Theme Facility" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Theme Facility</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/facility.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+  </ul>
+</aside>
+
+

--- a/docs/68/table-of-contents.html
+++ b/docs/68/table-of-contents.html
@@ -1,0 +1,24 @@
+<div class="hidden w-[350px] lg:pl-[28px] 2xl:block">
+  <div class="cs-scrollbar sticky top-[105px] hidden max-h-[calc(100vh-100px)] overflow-auto pt-10 lg:block lg:overflow-auto lg:transition-none 2xl:block">
+    <div id="toc-wrapper">
+      <div class="toc-heading">
+        <h2 class="text-h5 font-medium">Table of Contents</h2>
+      </div>
+      <nav id="TableOfContents">
+        <ol>
+          <li>
+            <ol>
+              <li><a href="#1-what-are-overlays-and-stream-tools">1. What Are Overlays and Stream Tools?</a></li>
+              <li><a href="#2-how-to-install-overlays-from-the-marketplace">2. How to Install Overlays from the Marketplace</a></li>
+              <li><a href="#3-managing-overlays-in-noiz-studio">3. Managing Overlays in NOIZ Studio</a></li>
+              <li><a href="#4-custom-overlay-uploads">4. Custom Overlay Uploads</a></li>
+              <li><a href="#5-linking-overlays-with-plugins">5. Linking Overlays with Plugins</a></li>
+              <li><a href="#6-performance-and-compatibility">6. Performance &amp; Compatibility</a></li>
+              <li><a href="#7-faq">7. FAQ</a></li>
+            </ol>
+          </li>
+        </ol>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/docs/documents.json
+++ b/docs/documents.json
@@ -680,5 +680,15 @@
       "viewers",
       "streaming"
     ]
+  },
+  {
+    "documentId": 68,
+    "title": "Installing and Managing Overlays and Tools on NOIZ",
+    "desccription": "How to install overlay packs, manage overlays, and optimize performance.",
+    "tags": [
+      "overlays",
+      "tools",
+      "plugins"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- document installing and managing overlays and stream tools in NOIZ Studio and OBS
- list new overlay guide in documentation index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689517307fac8324843b1fe6a9ead24c