### PR TITLE
Add viewer rewards guide

### DIFF
--- a/docs/71/article.html
+++ b/docs/71/article.html
@@ -1,0 +1,101 @@
+<div class="lg:w-[calc(100%-380px)] lg:border-l lg:border-l-border lg:pl-0 2xl:w-[calc(100%-380px-350px)] 2xl:pr-0 2xl:border-r 2xl:border-r-border">
+  <div class="max-w-full px-0 pt-7 lg:pt-10 lg:pl-[46px] 2xl:pr-[46px]">
+    <article class="content prose max-w-full px-0 py-0">
+      <blockquote>Viewer rewards on NOIZ are cosmetic, digital-only unlockables earned through Quests, milestones, or streamer interaction. They never include real-world value and are safely stored in your profile inventory.</blockquote>
+      <h2 id="what-are-collectible-viewer-rewards-on-noiz">1. What Are Collectible Viewer Rewards on NOIZ?</h2>
+      <p>Viewer rewards are cosmetic digital items earned through:</p>
+      <ul>
+        <li><strong>Quests</strong></li>
+        <li><strong>Viewer milestones</strong> (like Vibe or ⚡︎dB support)</li>
+        <li><strong>Sponsored campaigns</strong></li>
+        <li><strong>Event-specific achievements</strong></li>
+        <li><strong>Manual grants</strong> by streamers (via Reverb or plugins)</li>
+      </ul>
+      <p>These rewards are:</p>
+      <ul>
+        <li><strong>Non-transferable</strong></li>
+        <li>Stored in each viewer’s <strong>Profile Inventory</strong></li>
+        <li>Often <strong>visible in chat or on stream panels</strong></li>
+      </ul>
+      <h2 id="types-of-viewer-rewards">2. Types of Viewer Rewards</h2>
+      <table>
+        <thead>
+          <tr><th>Type</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>🏅 <strong>Badges</strong></td><td>Displayed in chat; includes time-based, Vibe, gift, Quest, and event types</td></tr>
+          <tr><td>🎨 <strong>Emotes</strong></td><td>Unlockable global or channel emotes from quests or sub levels</td></tr>
+          <tr><td>📦 <strong>Overlay Unlocks</strong></td><td>Visual effects or plugin themes earned during special campaigns</td></tr>
+          <tr><td>🧩 <strong>Reverb Rewards</strong></td><td>Channel point redemptions (e.g., "highlight my message")</td></tr>
+        </tbody>
+      </table>
+      <h2 id="how-streamers-can-grant-rewards">3. How Streamers Can Grant Rewards</h2>
+      <p>Streamers configure custom unlocks via:<br><strong>Dashboard → Interactivity → Viewer Rewards</strong></p>
+      <p>They can:</p>
+      <ul>
+        <li>Create <strong>Reverb-based redemptions</strong> (channel point equivalents)</li>
+        <li>Assign <strong>Quest-based badges</strong></li>
+        <li>Launch <strong>limited-time event unlocks</strong></li>
+        <li>Tie rewards to:
+          <ul>
+            <li>⚡︎dB tip levels</li>
+            <li>Gift sub milestones</li>
+            <li>Plugin triggers</li>
+          </ul>
+        </li>
+      </ul>
+      <p>All streamer-created rewards:</p>
+      <ul>
+        <li>Must remain <strong>cosmetic-only</strong></li>
+        <li>Are subject to <strong>branding, maturity, and TOS moderation</strong></li>
+      </ul>
+      <h2 id="viewer-progression-systems">4. Viewer Progression Systems</h2>
+      <p>Viewer rewards align with multiple systems:</p>
+      <ul>
+        <li><strong>Quest chains</strong></li>
+        <li><strong>Vibe milestones</strong></li>
+        <li><strong>Gift sub counts</strong> (5, 10, 25… 5,000)</li>
+        <li><strong>Channel loyalty</strong> (1m to 10y time badges)</li>
+      </ul>
+      <p>Badge types include:</p>
+      <ul>
+        <li>🎯 <strong>Personal Progress</strong> – shown in profile</li>
+        <li>💬 <strong>Chat Badges</strong> – shown next to username</li>
+        <li>🛠 <strong>Functional Unlocks</strong> – used via Reverb or plugins</li>
+      </ul>
+      <h2 id="event-sponsored-rewards">5. Event &amp; Sponsored Rewards</h2>
+      <p>During platform events or brand-sponsored quests:</p>
+      <ul>
+        <li>Viewers unlock <strong>exclusive, time-gated cosmetics</strong></li>
+        <li>Some react dynamically to plugins (e.g. flash when a hype goal is met)</li>
+        <li>Most are tied to <strong>specific games or streamers</strong></li>
+      </ul>
+      <p>Sponsored reward rules:</p>
+      <ul>
+        <li>Must be <strong>pre-approved</strong></li>
+        <li>Always show <strong>expiration dates</strong></li>
+        <li>May not include <strong>physical goods or money-equivalent prizes</strong></li>
+      </ul>
+      <h2 id="storage-and-display">6. Storage and Display</h2>
+      <p>All unlocked rewards go to:<br><strong>Profile → Inventory → Viewer Rewards</strong></p>
+      <p>Viewers can:</p>
+      <ul>
+        <li>Equip <strong>up to 3 badges</strong> (static or rotating)</li>
+        <li>Preview unlocked <strong>emotes, overlays, collectibles</strong></li>
+        <li>Filter rewards by:
+          <ul>
+            <li>Quest</li>
+            <li>Streamer</li>
+            <li>Platform</li>
+          </ul>
+        </li>
+        <li>View progress:<br><em>e.g., “3/10 Vibe badges earned”</em></li>
+      </ul>
+      <h2 id="faq">7. FAQ</h2>
+      <p><strong>Can streamers give rewards manually?</strong><br>→ Yes — via Reverb actions or Quest plugins</p>
+      <p><strong>Can I trade or gift my rewards?</strong><br>→ No — all viewer rewards are non-transferable</p>
+      <p><strong>Can I lose rewards?</strong><br>→ Only if removed for policy violations or if they expire</p>
+      <p><strong>Can rewards be used in chat?</strong><br>→ Yes — most show up as badges or unlock custom emotes</p>
+    </article>
+  </div>
+</div>

--- a/docs/71/sidebar.html
+++ b/docs/71/sidebar.html
@@ -1,0 +1,114 @@
+<aside class="sidebar overflow-auto lg:!sticky lg:!top-[95px] lg:max-h-[calc(100vh-100px)] lg:!w-full lg:!py-10 lg:!pr-[46px]">
+  <form class="border-border mb-10 hidden w-full justify-between rounded-xl border sm:rounded-2xl lg:flex">
+    <input type="search" class="font-secondary placeholder:text-text/50 w-full border-0 bg-transparent p-3 pl-6 pr-0 placeholder:text-sm focus:border-0 focus:ring-0" data-target="search-modal" placeholder="Search The Doc">
+    <button data-target="search-modal" type="button" class="pl-3 pr-6">
+      <i class="fa-solid fa-magnifying-glass text-theme-dark"></i>
+    </button>
+  </form>
+  <ul class="sidebar-list">
+    <li data-nav-id="" title="Getting Started" class="active group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Getting Started</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/start.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="active group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/requirments/" data-accordion="">Requirments</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/installation/" data-accordion="">Installation</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/configuration/" data-accordion="">Configuration</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/customization/" data-accordion="">Customization</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/elements/" data-accordion="">Elements</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Account Bill" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Account Bill</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/bill.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/windows/" data-accordion="">Windows</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Our Features" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Our Features</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/feature.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Theme Facility" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Theme Facility</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/facility.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+  </ul>
+</aside>
+
+

--- a/docs/71/table-of-contents.html
+++ b/docs/71/table-of-contents.html
@@ -1,0 +1,24 @@
+<div class="hidden w-[350px] lg:pl-[28px] 2xl:block">
+  <div class="cs-scrollbar sticky top-[105px] hidden max-h-[calc(100vh-100px)] overflow-auto pt-10 lg:block lg:overflow-auto lg:transition-none 2xl:block">
+    <div id="toc-wrapper">
+      <div class="toc-heading">
+        <h2 class="text-h5 font-medium">Table of Contents</h2>
+      </div>
+      <nav id="TableOfContents">
+        <ol>
+          <li>
+            <ol>
+              <li><a href="#what-are-collectible-viewer-rewards-on-noiz">1. What Are Collectible Viewer Rewards on NOIZ?</a></li>
+              <li><a href="#types-of-viewer-rewards">2. Types of Viewer Rewards</a></li>
+              <li><a href="#how-streamers-can-grant-rewards">3. How Streamers Can Grant Rewards</a></li>
+              <li><a href="#viewer-progression-systems">4. Viewer Progression Systems</a></li>
+              <li><a href="#event-sponsored-rewards">5. Event &amp; Sponsored Rewards</a></li>
+              <li><a href="#storage-and-display">6. Storage and Display</a></li>
+              <li><a href="#faq">7. FAQ</a></li>
+            </ol>
+          </li>
+        </ol>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/docs/documents.json
+++ b/docs/documents.json
@@ -93,8 +93,8 @@
   },
   {
     "documentId": 10,
-    "title": "Earning Before Affiliate – What You Can Do",
-    "desccription": "How to earn ⚡︎dB before reaching Affiliate status.",
+    "title": "Earning Before Affiliate \u2013 What You Can Do",
+    "desccription": "How to earn \u26a1\ufe0edB before reaching Affiliate status.",
     "tags": [
       "monetization",
       "affiliate",
@@ -195,7 +195,7 @@
   {
     "documentId": 20,
     "title": "Earnings Dashboard FAQ (My Loot)",
-    "desccription": "FAQ for using the My Loot dashboard, tracking ⚡︎dB, and cashout eligibility.",
+    "desccription": "FAQ for using the My Loot dashboard, tracking \u26a1\ufe0edB, and cashout eligibility.",
     "tags": [
       "monetization",
       "dashboard",
@@ -225,7 +225,7 @@
   {
     "documentId": 23,
     "title": "Constellation Linking, Custody, and Withdrawals",
-    "desccription": "How Constellation handles account linking, Decibel custody, and ⚡︎dB withdrawals.",
+    "desccription": "How Constellation handles account linking, Decibel custody, and \u26a1\ufe0edB withdrawals.",
     "tags": [
       "constellation",
       "db",
@@ -477,7 +477,7 @@
   },
   {
     "documentId": 48,
-    "title": "How DCT Reviews Reports & Makes Decisions — Section Breakdown",
+    "title": "How DCT Reviews Reports & Makes Decisions \u2014 Section Breakdown",
     "desccription": "Breakdown of DCT review process, actions, and appeal guidelines.",
     "tags": [
       "moderation",
@@ -497,7 +497,7 @@
   },
   {
     "documentId": 50,
-    "title": "When Cases Are Escalated to Staff Admins — Full Policy",
+    "title": "When Cases Are Escalated to Staff Admins \u2014 Full Policy",
     "desccription": "Policy on escalation to Staff Admins, their authority, and how to request review.",
     "tags": [
       "moderation",
@@ -507,7 +507,7 @@
   },
   {
     "documentId": 51,
-    "title": "DCT Tools, Powers, and Limitations — Full Policy",
+    "title": "DCT Tools, Powers, and Limitations \u2014 Full Policy",
     "desccription": "Full policy on DCT enforcement tools, authority, and limits.",
     "tags": [
       "moderation",
@@ -517,7 +517,7 @@
   },
   {
     "documentId": 52,
-    "title": "DCT Transparency Reports & Enforcement History — Full Policy",
+    "title": "DCT Transparency Reports & Enforcement History \u2014 Full Policy",
     "desccription": "How moderation transparency reports work and how enforcement history is tracked.",
     "tags": [
       "moderation",
@@ -557,7 +557,7 @@
   },
   {
     "documentId": 56,
-    "title": "Dual Streaming: What’s Allowed and What’s Not",
+    "title": "Dual Streaming: What\u2019s Allowed and What\u2019s Not",
     "desccription": "Guidelines for simulcasting your NOIZ streams to other platforms.",
     "tags": [
       "streaming",
@@ -610,7 +610,7 @@
   {
     "documentId": 61,
     "title": "Embedding NOIZ Streams on External Sites",
-    "desccription": "How to share your stream across the web — safely and effectively",
+    "desccription": "How to share your stream across the web \u2014 safely and effectively",
     "tags": [
       "streaming",
       "embedding",
@@ -711,6 +711,17 @@
       "chat",
       "moderation",
       "commands"
+    ]
+  },
+  {
+    "documentId": 71,
+    "title": "Creating Collectible Viewer Rewards (Badges, Quests, Unlockables)",
+    "desccription": "How to create and manage cosmetic viewer rewards like badges, quests, and unlockables.",
+    "tags": [
+      "rewards",
+      "badges",
+      "quests",
+      "inventory"
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- add guide on collectible viewer rewards covering badges, quests, and unlockables
- register new viewer rewards document in documents index

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68951feb26788324a44df76d2a2d9704