### PR TITLE
Add Content Ownership & Commission Transparency documentation

### DIFF
--- a/docs/78/article.html
+++ b/docs/78/article.html
@@ -1,0 +1,96 @@
+<div class="lg:w-[calc(100%-380px)] lg:border-l lg:border-l-border lg:pl-0 2xl:w-[calc(100%-380px-350px)] 2xl:pr-0 2xl:border-r 2xl:border-r-border">
+  <div class="max-w-full px-0 pt-7 lg:pt-10 lg:pl-[46px] 2xl:pr-[46px]">
+    <article class="content prose max-w-full px-0 py-0">
+      <blockquote>
+        <p>This policy ensures <strong>all Marketplace assets are properly credited, licensed, and rights-protected</strong> — safeguarding:</p>
+        <ul>
+          <li>Artists from stolen/resold work</li>
+          <li>Buyers from unknowingly purchasing unlicensed assets</li>
+          <li>Streamers from TOS violations over asset use</li>
+          <li>NOIZ from legal disputes involving misrepresented content</li>
+        </ul>
+      </blockquote>
+      <h2 id="1-why-this-matters">1. Why This Matters</h2>
+      <p>Accurate ownership and rights disclosure prevents:</p>
+      <ul>
+        <li>Uncredited asset resale</li>
+        <li>Buyers losing access to art they thought they owned</li>
+        <li>Streamers being banned for using stolen content</li>
+        <li>NOIZ facing legal claims over improperly licensed Marketplace items</li>
+      </ul>
+      <h2 id="2-who-owns-what-on-noiz">2. Who Owns What on NOIZ</h2>
+      <p>By default:</p>
+      <ul>
+        <li>The <strong>original creator</strong> of a listing holds the copyright</li>
+        <li>NOIZ receives a <strong>limited license</strong> to display/distribute it digitally</li>
+        <li>Buyers receive a <strong>non-transferable, personal-use license</strong> for NOIZ use only</li>
+      </ul>
+      <p><strong>Assets cannot be:</strong></p>
+      <ul>
+        <li>Resold</li>
+        <li>Sublicensed</li>
+        <li>Exported off-platform — unless the listing explicitly includes those rights.</li>
+      </ul>
+      <h2 id="3-commissioned-work-requirements">3. Commissioned Work Requirements</h2>
+      <p>If you upload work that was:</p>
+      <ul>
+        <li>Commissioned by someone else</li>
+        <li>Created collaboratively by multiple people</li>
+      </ul>
+      <p>You must:</p>
+      <ul>
+        <li>Provide <strong>proof of rights</strong> (signed contract, agreement, or explicit license)</li>
+        <li>Disclose in the listing that it’s <strong>collaborative or licensed</strong> work</li>
+        <li>Use <strong>accurate credits</strong> (NOIZ supports co-listing &amp; attribution tags)</li>
+      </ul>
+      <p>Failure to comply may result in:</p>
+      <ul>
+        <li>Listing removal</li>
+        <li>⚡︎dB earnings freeze</li>
+        <li>Marketplace access suspension</li>
+      </ul>
+      <h2 id="4-collaborative-projects">4. Collaborative Projects</h2>
+      <p>You may publish collaborative assets if:</p>
+      <ul>
+        <li>All contributors are <strong>credited</strong></li>
+        <li>One uploader is designated as <strong>payout owner</strong></li>
+        <li>Co-creators are tagged in the listing (visible or silent credit)</li>
+      </ul>
+      <blockquote>
+        <p>Shared revenue features are planned, but not yet available — payouts currently go to the uploader’s account.</p>
+      </blockquote>
+      <h2 id="5-accepting-commissions-via-noiz">5. Accepting Commissions via NOIZ</h2>
+      <p>Verified Artists can:</p>
+      <ul>
+        <li>Accept <strong>⚡︎dB commissions</strong> (manual or Marketplace listing)</li>
+        <li>Enable <strong>“Commission Available”</strong> toggle on their storefront</li>
+        <li>Mark listings as <strong>“Commissioned By”</strong> with viewer-submitted credit</li>
+      </ul>
+      <p>Commission listings must include:</p>
+      <ul>
+        <li><strong>Rights granted</strong> (e.g., “NOIZ use only” vs. “full rights granted”)</li>
+        <li>Public or private listing status (private = not searchable)</li>
+        <li>Optional watermark or client alias in previews</li>
+      </ul>
+      <h2 id="6-whats-not-allowed">6. What’s Not Allowed</h2>
+      <p>❌ Strictly prohibited:</p>
+      <ul>
+        <li>Uploading work you didn’t create or license</li>
+        <li>Listing Fiverr/AI-generated art <strong>without credit and licensing rights</strong></li>
+        <li>Using false credits to obtain Verified Artist status</li>
+        <li>Mass-reposting Twitch or other platform assets <strong>without adapting to NOIZ licensing</strong></li>
+      </ul>
+      <h2 id="7-faq">7. FAQ</h2>
+      <dl>
+        <dt>Can I sell something I made for Twitch?</dt>
+        <dd>Yes, if you fully own the rights and relicense it for NOIZ.</dd>
+        <dt>Can I post fanart of a copyrighted character?</dt>
+        <dd>No — fanart of copyrighted IP cannot be listed in the Marketplace.</dd>
+        <dt>Can I credit someone who helped but doesn’t want payout?</dt>
+        <dd>Yes — add acknowledgment in the description.</dd>
+        <dt>Can buyers use my art off-platform?</dt>
+        <dd>Only if the license <strong>explicitly</strong> allows it.</dd>
+      </dl>
+    </article>
+  </div>
+</div>

--- a/docs/78/sidebar.html
+++ b/docs/78/sidebar.html
@@ -1,0 +1,114 @@
+<aside class="sidebar overflow-auto lg:!sticky lg:!top-[95px] lg:max-h-[calc(100vh-100px)] lg:!w-full lg:!py-10 lg:!pr-[46px]">
+  <form class="border-border mb-10 hidden w-full justify-between rounded-xl border sm:rounded-2xl lg:flex">
+    <input type="search" class="font-secondary placeholder:text-text/50 w-full border-0 bg-transparent p-3 pl-6 pr-0 placeholder:text-sm focus:border-0 focus:ring-0" data-target="search-modal" placeholder="Search The Doc">
+    <button data-target="search-modal" type="button" class="pl-3 pr-6">
+      <i class="fa-solid fa-magnifying-glass text-theme-dark"></i>
+    </button>
+  </form>
+  <ul class="sidebar-list">
+    <li data-nav-id="" title="Getting Started" class="active group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Getting Started</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/start.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="active group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/requirments/" data-accordion="">Requirments</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/installation/" data-accordion="">Installation</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/configuration/" data-accordion="">Configuration</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/customization/" data-accordion="">Customization</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/elements/" data-accordion="">Elements</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Account Bill" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Account Bill</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/bill.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/windows/" data-accordion="">Windows</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Our Features" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Our Features</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/feature.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Theme Facility" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Theme Facility</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/facility.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+  </ul>
+</aside>
+
+

--- a/docs/78/table-of-contents.html
+++ b/docs/78/table-of-contents.html
@@ -1,0 +1,24 @@
+<div class="hidden w-[350px] lg:pl-[28px] 2xl:block">
+  <div class="cs-scrollbar sticky top-[105px] hidden max-h-[calc(100vh-100px)] overflow-auto pt-10 lg:block lg:overflow-auto lg:transition-none 2xl:block">
+    <div id="toc-wrapper">
+      <div class="toc-heading">
+        <h2 class="text-h5 font-medium">Table of Contents</h2>
+      </div>
+      <nav id="TableOfContents">
+        <ol>
+          <li>
+            <ol>
+              <li><a href="#1-why-this-matters">1. Why This Matters</a></li>
+              <li><a href="#2-who-owns-what-on-noiz">2. Who Owns What on NOIZ</a></li>
+              <li><a href="#3-commissioned-work-requirements">3. Commissioned Work Requirements</a></li>
+              <li><a href="#4-collaborative-projects">4. Collaborative Projects</a></li>
+              <li><a href="#5-accepting-commissions-via-noiz">5. Accepting Commissions via NOIZ</a></li>
+              <li><a href="#6-whats-not-allowed">6. What’s Not Allowed</a></li>
+              <li><a href="#7-faq">7. FAQ</a></li>
+            </ol>
+          </li>
+        </ol>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/docs/documents.json
+++ b/docs/documents.json
@@ -93,8 +93,8 @@
   },
   {
     "documentId": 10,
-    "title": "Earning Before Affiliate \u2013 What You Can Do",
-    "desccription": "How to earn \u26a1\ufe0edB before reaching Affiliate status.",
+    "title": "Earning Before Affiliate – What You Can Do",
+    "desccription": "How to earn ⚡︎dB before reaching Affiliate status.",
     "tags": [
       "monetization",
       "affiliate",
@@ -195,7 +195,7 @@
   {
     "documentId": 20,
     "title": "Earnings Dashboard FAQ (My Loot)",
-    "desccription": "FAQ for using the My Loot dashboard, tracking \u26a1\ufe0edB, and cashout eligibility.",
+    "desccription": "FAQ for using the My Loot dashboard, tracking ⚡︎dB, and cashout eligibility.",
     "tags": [
       "monetization",
       "dashboard",
@@ -225,7 +225,7 @@
   {
     "documentId": 23,
     "title": "Constellation Linking, Custody, and Withdrawals",
-    "desccription": "How Constellation handles account linking, Decibel custody, and \u26a1\ufe0edB withdrawals.",
+    "desccription": "How Constellation handles account linking, Decibel custody, and ⚡︎dB withdrawals.",
     "tags": [
       "constellation",
       "db",
@@ -477,7 +477,7 @@
   },
   {
     "documentId": 48,
-    "title": "How DCT Reviews Reports & Makes Decisions \u2014 Section Breakdown",
+    "title": "How DCT Reviews Reports & Makes Decisions — Section Breakdown",
     "desccription": "Breakdown of DCT review process, actions, and appeal guidelines.",
     "tags": [
       "moderation",
@@ -497,7 +497,7 @@
   },
   {
     "documentId": 50,
-    "title": "When Cases Are Escalated to Staff Admins \u2014 Full Policy",
+    "title": "When Cases Are Escalated to Staff Admins — Full Policy",
     "desccription": "Policy on escalation to Staff Admins, their authority, and how to request review.",
     "tags": [
       "moderation",
@@ -507,7 +507,7 @@
   },
   {
     "documentId": 51,
-    "title": "DCT Tools, Powers, and Limitations \u2014 Full Policy",
+    "title": "DCT Tools, Powers, and Limitations — Full Policy",
     "desccription": "Full policy on DCT enforcement tools, authority, and limits.",
     "tags": [
       "moderation",
@@ -517,7 +517,7 @@
   },
   {
     "documentId": 52,
-    "title": "DCT Transparency Reports & Enforcement History \u2014 Full Policy",
+    "title": "DCT Transparency Reports & Enforcement History — Full Policy",
     "desccription": "How moderation transparency reports work and how enforcement history is tracked.",
     "tags": [
       "moderation",
@@ -557,7 +557,7 @@
   },
   {
     "documentId": 56,
-    "title": "Dual Streaming: What\u2019s Allowed and What\u2019s Not",
+    "title": "Dual Streaming: What’s Allowed and What’s Not",
     "desccription": "Guidelines for simulcasting your NOIZ streams to other platforms.",
     "tags": [
       "streaming",
@@ -610,7 +610,7 @@
   {
     "documentId": 61,
     "title": "Embedding NOIZ Streams on External Sites",
-    "desccription": "How to share your stream across the web \u2014 safely and effectively",
+    "desccription": "How to share your stream across the web — safely and effectively",
     "tags": [
       "streaming",
       "embedding",
@@ -784,6 +784,17 @@
       "marketplace",
       "submission",
       "guidelines"
+    ]
+  },
+  {
+    "documentId": 78,
+    "title": "Content Ownership & Commission Transparency",
+    "desccription": "Policy ensuring Marketplace assets are credited, licensed, and rights-protected.",
+    "tags": [
+      "artist",
+      "marketplace",
+      "policy",
+      "commission"
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- add document on ownership and commission transparency for marketplace assets
- document covers default licensing, commissioned work rules, commission features, and prohibited actions
- register document in documents.json

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895639ef98c8324b298b5ed440315ee