### PR TITLE
Add Marketplace Asset Guidelines document

### DIFF
--- a/docs/80/article.html
+++ b/docs/80/article.html
@@ -1,0 +1,118 @@
+<div class="lg:w-[calc(100%-380px)] lg:border-l lg:border-l-border lg:pl-0 2xl:w-[calc(100%-380px-350px)] 2xl:pr-0 2xl:border-r 2xl:border-r-border">
+  <div class="max-w-full px-0 pt-7 lg:pt-10 lg:pl-[46px] 2xl:pr-[46px]">
+    <article class="content prose max-w-full px-0 py-0">
+      <blockquote>
+        <p>These guidelines outline visual, audio, and plugin-connected asset requirements for the NOIZ Marketplace to ensure quality, performance, and legal safety.</p>
+      </blockquote>
+      <h2 id="1-what-these-guidelines-cover">1. What These Guidelines Cover</h2>
+      <p>This document outlines requirements for:</p>
+      <ul>
+        <li>Static and animated overlay packs</li>
+        <li>Audio files for alerts, transitions, or stingers</li>
+        <li>Plugin-connected UI assets or effects</li>
+        <li>Combined visual + sound bundles</li>
+      </ul>
+      <p>These rules ensure everything in the Marketplace:</p>
+      <ul>
+        <li>Looks good on-stream</li>
+        <li>Performs well across devices</li>
+        <li>Is legally safe to use</li>
+        <li>Integrates cleanly into NOIZ Studio and compatible OBS setups</li>
+      </ul>
+      <h2 id="2-visual-overlays-scenes">2. Visual Overlays &amp; Scenes</h2>
+      <p><strong>Accepted formats:</strong></p>
+      <ul>
+        <li>PNG / WebP (static)</li>
+        <li>WebM / Lottie / SVG (animated)</li>
+      </ul>
+      <p><strong>Guidelines:</strong></p>
+      <ul>
+        <li>Max canvas: 1920x1080 unless explicitly scalable</li>
+        <li>Transparent where needed (e.g., camera frame windows)</li>
+        <li>Looping animations must be seamless</li>
+        <li>Total pack size should stay under 25MB per scene</li>
+      </ul>
+      <p><strong>Avoid:</strong></p>
+      <ul>
+        <li>Text baked into overlays (use dynamic plugin labels when possible)</li>
+        <li>Platform branding (NOIZ logos or Partner badges) unless officially sanctioned</li>
+        <li>Watermarks in final files (preview watermarks are fine)</li>
+      </ul>
+      <h2 id="3-audio-alerts-transitions-sfx">3. Audio Alerts, Transitions &amp; SFX</h2>
+      <p><strong>Accepted formats:</strong></p>
+      <ul>
+        <li>MP3 / WAV / OGG</li>
+      </ul>
+      <p><strong>Guidelines:</strong></p>
+      <ul>
+        <li>Under 10 seconds per file</li>
+        <li>No clipping, peaking, or distortion</li>
+        <li>Clearly categorized (e.g., alert tone, horror stinger, retro pop)</li>
+        <li>Volume normalized (target -14 LUFS)</li>
+      </ul>
+      <p><strong>Optional:</strong></p>
+      <ul>
+        <li>Only include original or license-free work</li>
+        <li>Label loop-friendly ambient sounds clearly</li>
+      </ul>
+      <h2 id="4-plugin-linked-assets">4. Plugin-Linked Assets</h2>
+      <p>These are overlays or audio files designed to sync with NOIZ plugins, including:</p>
+      <ul>
+        <li>Reaction flares</li>
+        <li>Quest notifications</li>
+        <li>Tip/sub event animations</li>
+        <li>Progress bars or token counters</li>
+      </ul>
+      <p><strong>Requirements:</strong></p>
+      <ul>
+        <li>Include setup or integration notes</li>
+        <li>Preview images should reflect in-plugin use</li>
+        <li>Assets must be responsive (scalable/adaptive for mobile)</li>
+      </ul>
+      <p><strong>Plugins must not:</strong></p>
+      <ul>
+        <li>Mislead users (e.g., fake alerts)</li>
+        <li>Use copyrighted game/show sounds</li>
+        <li>Break sandboxed layout areas</li>
+      </ul>
+      <h2 id="5-bundling-naming-conventions">5. Bundling &amp; Naming Conventions</h2>
+      <p>For Marketplace clarity:</p>
+      <ul>
+        <li>Group assets into themed unlock packs (e.g., “Cyberpunk Stream Kit”)</li>
+        <li>Include version/date tags if updated (e.g., v1.2, “Summer 2025”)</li>
+        <li>Use consistent filenames (alert_sub_loop.webm, brb_scene.png, sfx_ding.ogg)</li>
+        <li>Keep folder structures clean — avoid deeply nested directories</li>
+      </ul>
+      <h2 id="6-tagging-descriptions">6. Tagging &amp; Descriptions</h2>
+      <p>Required for discovery:</p>
+      <ul>
+        <li><strong>Style tags:</strong> pixel, vaporwave, glitch, etc.</li>
+        <li><strong>Function tags:</strong> starting scene, emote alert, SFX, etc.</li>
+        <li><strong>Usage notes:</strong> “Works with Quest plugin,” “Optimized for mobile,” etc.</li>
+        <li>List of included files and formats</li>
+      </ul>
+      <p><strong>Avoid:</strong></p>
+      <ul>
+        <li>Misleading titles like “Twitch Animated Super Pack”</li>
+        <li>Using NOIZ brand names or Partner terms without authorization</li>
+      </ul>
+      <h2 id="7-unlock-access-notes">7. Unlock &amp; Access Notes</h2>
+      <ul>
+        <li>Marketplace items are <strong>unlocked by viewers</strong> using ⚡︎dB — they are <strong>digital-only platform assets</strong>, not direct purchases or physical goods</li>
+        <li>Artists receive ⚡︎dB allocations when their items are unlocked, based on their Artist Tier</li>
+        <li>Items cannot be transferred, exported for resale, or sublicensed without explicit licensing</li>
+      </ul>
+      <h2 id="8-faq">8. FAQ</h2>
+      <dl>
+        <dt>Can I use AI-generated art?</dt>
+        <dd>Only if fully edited and legally cleared for licensing</dd>
+        <dt>Can I submit free packs?</dt>
+        <dd>Yes — free listings still go through moderation</dd>
+        <dt>Can I upload extracted or modded game assets?</dt>
+        <dd>No — must be original or fully licensed</dd>
+        <dt>Do I need installation instructions?</dt>
+        <dd>Strongly encouraged, especially for plugin-reactive packs</dd>
+      </dl>
+    </article>
+  </div>
+</div>

--- a/docs/80/sidebar.html
+++ b/docs/80/sidebar.html
@@ -1,0 +1,114 @@
+<aside class="sidebar overflow-auto lg:!sticky lg:!top-[95px] lg:max-h-[calc(100vh-100px)] lg:!w-full lg:!py-10 lg:!pr-[46px]">
+  <form class="border-border mb-10 hidden w-full justify-between rounded-xl border sm:rounded-2xl lg:flex">
+    <input type="search" class="font-secondary placeholder:text-text/50 w-full border-0 bg-transparent p-3 pl-6 pr-0 placeholder:text-sm focus:border-0 focus:ring-0" data-target="search-modal" placeholder="Search The Doc">
+    <button data-target="search-modal" type="button" class="pl-3 pr-6">
+      <i class="fa-solid fa-magnifying-glass text-theme-dark"></i>
+    </button>
+  </form>
+  <ul class="sidebar-list">
+    <li data-nav-id="" title="Getting Started" class="active group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Getting Started</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/start.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="active group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/requirments/" data-accordion="">Requirments</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/installation/" data-accordion="">Installation</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/configuration/" data-accordion="">Configuration</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/customization/" data-accordion="">Customization</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/elements/" data-accordion="">Elements</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Account Bill" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Account Bill</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/bill.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/windows/" data-accordion="">Windows</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Our Features" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Our Features</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/feature.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Theme Facility" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Theme Facility</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/facility.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+  </ul>
+</aside>
+
+

--- a/docs/80/table-of-contents.html
+++ b/docs/80/table-of-contents.html
@@ -1,0 +1,25 @@
+<div class="hidden w-[350px] lg:pl-[28px] 2xl:block">
+  <div class="cs-scrollbar sticky top-[105px] hidden max-h-[calc(100vh-100px)] overflow-auto pt-10 lg:block lg:overflow-auto lg:transition-none 2xl:block">
+    <div id="toc-wrapper">
+      <div class="toc-heading">
+        <h2 class="text-h5 font-medium">Table of Contents</h2>
+      </div>
+      <nav id="TableOfContents">
+        <ol>
+          <li>
+            <ol>
+              <li><a href="#1-what-these-guidelines-cover">1. What These Guidelines Cover</a></li>
+              <li><a href="#2-visual-overlays-scenes">2. Visual Overlays &amp; Scenes</a></li>
+              <li><a href="#3-audio-alerts-transitions-sfx">3. Audio Alerts, Transitions &amp; SFX</a></li>
+              <li><a href="#4-plugin-linked-assets">4. Plugin-Linked Assets</a></li>
+              <li><a href="#5-bundling-naming-conventions">5. Bundling &amp; Naming Conventions</a></li>
+              <li><a href="#6-tagging-descriptions">6. Tagging &amp; Descriptions</a></li>
+              <li><a href="#7-unlock-access-notes">7. Unlock &amp; Access Notes</a></li>
+              <li><a href="#8-faq">8. FAQ</a></li>
+            </ol>
+          </li>
+        </ol>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/docs/documents.json
+++ b/docs/documents.json
@@ -804,5 +804,16 @@
       "monetization",
       "payouts"
     ]
+  },
+  {
+    "documentId": 80,
+    "title": "Marketplace Asset Guidelines (Overlays, Audio, Plugins, etc.)",
+    "desccription": "Requirements for overlay packs, audio, and plugin-linked assets in the NOIZ Marketplace.",
+    "tags": [
+      "artist",
+      "marketplace",
+      "assets",
+      "guidelines"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- add Marketplace Asset Guidelines covering overlays, audio, plugin-linked assets, and bundling standards
- register new document in documentation index

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689652237ae083249ca29308da870b62