### PR TITLE
Add Interactive Plugin SDK overview documentation

### DIFF
--- a/docs/92/article.html
+++ b/docs/92/article.html
@@ -1,0 +1,103 @@
+<div class="lg:w-[calc(100%-380px)] lg:border-l lg:border-l-border lg:pl-0 2xl:w-[calc(100%-380px-350px)] 2xl:pr-0 2xl:border-r 2xl:border-r-border">
+  <div class="max-w-full px-0 pt-7 lg:pt-10 lg:pl-[46px] 2xl:pr-[46px]">
+    <article class="content prose max-w-full px-0 py-0">
+      <h2 id="1-what-is-the-noiz-plugin-sdk">1. What Is the NOIZ Plugin SDK</h2>
+      <p>The NOIZ Plugin SDK allows Developers to build custom interactive features that streamers can add to their broadcasts, including:</p>
+      <ul>
+        <li>Real-time overlays (polls, chat reactions, quest progress bars)</li>
+        <li>Viewer-triggered effects (⚡︎dB-based events, emote bursts, animations)</li>
+        <li>Token-based unlockables tied to stream activity</li>
+        <li>Custom HUD elements or gameplay integrations</li>
+      </ul>
+      <p>All plugins run <strong>sandboxed</strong> in-browser or via NOIZ Studio and must follow platform-safe and security-approved practices.</p>
+
+      <h2 id="2-plugin-types">2. Plugin Types</h2>
+      <table>
+        <thead>
+          <tr><th>Plugin Type</th><th>Example Use Case</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><strong>Overlay Plugins</strong></td><td>Animated banners, follower counters, polls</td></tr>
+          <tr><td><strong>Interaction Plugins</strong></td><td>⚡︎dB-triggered animations, emoji storms</td></tr>
+          <tr><td><strong>Quest Plugins</strong></td><td>Show quest progress or viewer milestones</td></tr>
+          <tr><td><strong>Audio Plugins</strong></td><td>Play alert tones, ambient effects</td></tr>
+          <tr><td><strong>Utility Plugins</strong></td><td>Token counters, timers, vote tallies</td></tr>
+        </tbody>
+      </table>
+      <p>Plugins may run <strong>passively</strong> (always visible) or <strong>reactively</strong> (triggered by chat input, ⚡︎dB events, or platform signals).</p>
+
+      <h2 id="3-sdk-access">3. SDK Access</h2>
+      <p>To access the SDK, you must:</p>
+      <ol>
+        <li>Be a <strong>verified Developer</strong></li>
+        <li>Accept the <strong>Plugin SDK Terms</strong></li>
+        <li>Navigate to:
+          <ul>
+            <li><strong>Developers → Plugin Builder → Get SDK</strong></li>
+          </ul>
+        </li>
+      </ol>
+      <p>From there, you can:</p>
+      <ul>
+        <li>Download or fork the boilerplate kit</li>
+        <li>Connect to:
+          <ul>
+            <li>Chat signals</li>
+            <li>Viewer ⚡︎dB triggers</li>
+            <li>Stream status (live, hype, featured, etc.)</li>
+            <li>Inventory unlock events</li>
+          </ul>
+        </li>
+      </ul>
+      <p>The SDK supports JavaScript (React, Vue, or Vanilla), WebSocket hooks, and the NOIZ Event API.</p>
+
+      <h2 id="4-plugin-lifecycle">4. Plugin Lifecycle</h2>
+      <p>Each plugin follows a structured process:</p>
+      <ol>
+        <li><strong>Local Development</strong> — preview in dev mode</li>
+        <li><strong>Sandbox Testing</strong> — stream-safe environment without live chat posting</li>
+        <li><strong>Moderation Submission</strong> — for Marketplace listing or Quest integration</li>
+        <li><strong>Approval &amp; Release</strong> — streamers can install the plugin</li>
+        <li><strong>Ongoing Updates</strong> — versioning and update notes visible to users</li>
+      </ol>
+      <p>Plugins may be:</p>
+      <ul>
+        <li><strong>Free</strong></li>
+        <li><strong>Unlocked via ⚡︎dB</strong></li>
+        <li><strong>Included in platform event packs</strong></li>
+      </ul>
+
+      <h2 id="5-integration-features">5. Integration Features</h2>
+      <p>The NOIZ Plugin SDK supports:</p>
+      <ul>
+        <li><strong>Reactive listeners</strong> — <code>onTip</code>, <code>onSub</code>, <code>onQuestComplete</code>, <code>onKeyword</code></li>
+        <li><strong>Event triggers</strong> — <code>triggerOverlay</code>, <code>sendReaction</code>, <code>setCooldown</code></li>
+        <li><strong>Chat-safe callbacks</strong> — <code>chatEvent</code>, <code>viewerId</code>, <code>hasUnlock</code></li>
+        <li><strong>UI placement options</strong> — dock, banner, fullscreen, pinned corner</li>
+      </ul>
+      <p>Each plugin must clearly define:</p>
+      <ul>
+        <li>Resource use (CPU/network)</li>
+        <li>Whether it uses audio or visual effects</li>
+        <li>Any required permissions</li>
+      </ul>
+
+      <h2 id="6-security-model">6. Security Model</h2>
+      <p>Plugins are:</p>
+      <ul>
+        <li>Sandboxed in secure iframes or OBS layers</li>
+        <li>Prohibited from collecting personal data or browser/device info</li>
+        <li>Blocked from external requests unless pre-approved</li>
+        <li>Audited both automatically and manually for security compliance</li>
+      </ul>
+      <p>⚠️ <strong>Bypassing security layers</strong> will result in immediate removal and Developer badge revocation.</p>
+
+      <h2 id="7-faq">7. FAQ</h2>
+      <p><strong>Can I submit multiple plugins?</strong> → Yes, but each must go through approval individually.</p>
+      <p><strong>Can I monetize my plugin?</strong> → Yes, via ⚡︎dB unlocks or Dev Quest rewards.</p>
+      <p><strong>Can I update a plugin without review?</strong> → No — all changes require a moderation cycle.</p>
+      <p><strong>Can streamers customize plugin visuals?</strong> → Yes — if you provide editable config options.</p>
+      <p><strong>Is the SDK open source?</strong> → Core SDK tooling is public; runtime environment is proprietary.</p>
+    </article>
+  </div>
+</div>

--- a/docs/92/sidebar.html
+++ b/docs/92/sidebar.html
@@ -1,0 +1,114 @@
+<aside class="sidebar overflow-auto lg:!sticky lg:!top-[95px] lg:max-h-[calc(100vh-100px)] lg:!w-full lg:!py-10 lg:!pr-[46px]">
+  <form class="border-border mb-10 hidden w-full justify-between rounded-xl border sm:rounded-2xl lg:flex">
+    <input type="search" class="font-secondary placeholder:text-text/50 w-full border-0 bg-transparent p-3 pl-6 pr-0 placeholder:text-sm focus:border-0 focus:ring-0" data-target="search-modal" placeholder="Search The Doc">
+    <button data-target="search-modal" type="button" class="pl-3 pr-6">
+      <i class="fa-solid fa-magnifying-glass text-theme-dark"></i>
+    </button>
+  </form>
+  <ul class="sidebar-list">
+    <li data-nav-id="" title="Getting Started" class="active group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Getting Started</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/start.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="active group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/requirments/" data-accordion="">Requirments</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/installation/" data-accordion="">Installation</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/configuration/" data-accordion="">Configuration</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/customization/" data-accordion="">Customization</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/elements/" data-accordion="">Elements</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/getting-started/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Account Bill" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Account Bill</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/bill.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/windows/" data-accordion="">Windows</a></li>
+        <li class="group">
+          <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child</button>
+          <ul>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-1/" data-accordion="">Child 1</a></li>
+            <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-2/" data-accordion="">Child 2</a></li>
+            <li class="group">
+              <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3</button>
+              <ul>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.1/" data-accordion="">Child 3.1</a></li>
+                <li class="group">
+                  <button class="has-sibling-child" aria-label="Dropdown Collapse" data-accordion="">Child 3.2</button>
+                  <ul>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.1/" data-accordion="">Child 3.2.1</a></li>
+                    <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.2/child-3.2.2/" data-accordion="">Child 3.2.2</a></li>
+                  </ul>
+                </li>
+                <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/account-bill/child/child-3/child-3.3/" data-accordion="">Child 3.3</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Our Features" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Our Features</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/feature.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/our-features/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+    <li data-nav-id="" title="Theme Facility" class="group relative">
+      <div class="flex cursor-pointer select-none items-center gap-4" data-accordion="">
+        <h2 class="order-1 text-base font-medium group-[.active]:font-semibold sm:text-[20px] lg:text-[22px]">Theme Facility</h2>
+        <div class="order-0 bg-theme-light group-hover:bg-primary group-[.active]:bg-primary flex h-[40px] w-[40px] items-center justify-center rounded-md p-[10px] transition-colors duration-300 sm:h-[50px] sm:w-[50px]">
+          <img src="/docbox/site/images/icons/facility.svg" loading="lazy" decoding="async" alt="" class="h-5 w-5 img">
+        </div>
+      </div>
+      <ul class="group-[.active]:mt-4 group-[.active]:max-h-[1000px]">
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/linux/" data-accordion="">Linux</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/mac/" data-accordion="">Mac OS</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/routing/" data-accordion="">Routing</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/ubuntu/" data-accordion="">Ubuntu</a></li>
+        <li class="group"><a href="https://demo.gethugothemes.com/docbox/site/theme-facility/windows/" data-accordion="">Windows</a></li>
+      </ul>
+    </li>
+  </ul>
+</aside>
+
+

--- a/docs/92/table-of-contents.html
+++ b/docs/92/table-of-contents.html
@@ -1,0 +1,24 @@
+<div class="hidden w-[350px] lg:pl-[28px] 2xl:block">
+  <div class="cs-scrollbar sticky top-[105px] hidden max-h-[calc(100vh-100px)] overflow-auto pt-10 lg:block lg:overflow-auto lg:transition-none 2xl:block">
+    <div id="toc-wrapper">
+      <div class="toc-heading">
+        <h2 class="text-h5 font-medium">Table of Contents</h2>
+      </div>
+      <nav id="TableOfContents">
+        <ol>
+          <li>
+            <ol>
+              <li><a href="#1-what-is-the-noiz-plugin-sdk">1. What Is the NOIZ Plugin SDK</a></li>
+              <li><a href="#2-plugin-types">2. Plugin Types</a></li>
+              <li><a href="#3-sdk-access">3. SDK Access</a></li>
+              <li><a href="#4-plugin-lifecycle">4. Plugin Lifecycle</a></li>
+              <li><a href="#5-integration-features">5. Integration Features</a></li>
+              <li><a href="#6-security-model">6. Security Model</a></li>
+              <li><a href="#7-faq">7. FAQ</a></li>
+            </ol>
+          </li>
+        </ol>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/docs/documents.json
+++ b/docs/documents.json
@@ -929,5 +929,15 @@
       "plugins",
       "marketplace"
     ]
+  },
+  {
+    "documentId": 92,
+    "title": "Interactive Plugin SDK Overview",
+    "desccription": "How the NOIZ Plugin SDK lets developers build interactive overlays, events, and secure integrations.",
+    "tags": [
+      "developer",
+      "plugins",
+      "sdk"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- add developer documentation for the NOIZ Plugin SDK with plugin types, access instructions, lifecycle, features, and security model
- register the new article in `documents.json`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897659db8c08324b0bb6ba8dd9fd14e